### PR TITLE
fix(security): close audit findings in redaction, RPC panics and web UI cache

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,6 +62,19 @@ signs:
       - "${artifact}"
       - "${signature}"
       - "{{ .Env.MINISIGN_KEY_FILE }}"
+  # Sign the aggregate checksum manifest too. Each archive already carries its
+  # own .minisig, so per-artifact integrity was covered, but an unsigned
+  # checksums.txt is a tampering surface for anyone who verifies via the
+  # manifest instead of the individual signatures.
+  - id: bound-checksum-signature
+    artifacts: checksum
+    cmd: ./scripts/sign-release-artifact.sh
+    signature: "${artifact}.minisig"
+    stdin: "{{ .Env.MINISIGN_PASSWORD }}"
+    args:
+      - "${artifact}"
+      - "${signature}"
+      - "{{ .Env.MINISIGN_KEY_FILE }}"
 
 homebrew_casks:
   - name: cenvero-fleet

--- a/internal/agent/panicguard.go
+++ b/internal/agent/panicguard.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+)
+
+// guardPanic contains a panic to the single goroutine that raised it.
+//
+// Every per-connection and per-channel handler runs in its own goroutine and
+// parses input from the network. In Go an unrecovered panic in ANY goroutine
+// terminates the whole process, so without this a single latent nil-deref or
+// index-out-of-range reachable from a crafted envelope would take the agent
+// down for every connected controller — turning a localized bug into an
+// availability incident across the fleet.
+//
+// The decode paths are individually bounds-checked, so this is containment for
+// bugs not yet found rather than a fix for a known crash. Deferred callers
+// registered *before* this one (semaphore releases, channel closes) still run,
+// because deferred calls unwind LIFO after the recover.
+func guardPanic(what string) {
+	if r := recover(); r != nil {
+		fmt.Fprintf(os.Stderr, "fleet-agent: recovered panic in %s: %v\n%s\n", what, r, debug.Stack())
+	}
+}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -168,6 +168,7 @@ func (s Server) Serve(ctx context.Context, listener net.Listener) error {
 			var once sync.Once
 			releaseHandshake := func() { once.Do(func() { <-handshakeSlots }) }
 			defer releaseHandshake()
+			defer guardPanic("inbound connection")
 			_ = s.serveConnAfterAuth(rawConn, config, releaseHandshake)
 		}()
 	}
@@ -243,7 +244,7 @@ func (s Server) serveConnAfterAuth(rawConn net.Conn, config *ssh.ServerConfig, a
 	// Cap concurrent RPC/shell channels per connection so a peer can't fork-bomb
 	// the agent with unbounded channel opens (direct-tcpip has its own tunnelSlots
 	// cap). Each handler releases its slot when it returns.
-	const maxChannelsPerConn = 128
+	const maxChannelsPerConn = transport.MaxChannelsPerConn
 	chanSlots := make(chan struct{}, maxChannelsPerConn)
 	var firstAccepted sync.Once
 	markFirstAccepted := func() {
@@ -265,7 +266,11 @@ func (s Server) serveConnAfterAuth(rawConn net.Conn, config *ssh.ServerConfig, a
 			}
 			markFirstAccepted()
 			go ssh.DiscardRequests(requests)
-			go func() { defer func() { <-chanSlots }(); s.serveRPC(channel) }()
+			go func() {
+				defer func() { <-chanSlots }()
+				defer guardPanic("rpc channel")
+				s.serveRPC(channel)
+			}()
 		case transport.ShellChannelType:
 			select {
 			case chanSlots <- struct{}{}:
@@ -286,9 +291,28 @@ func (s Server) serveConnAfterAuth(rawConn net.Conn, config *ssh.ServerConfig, a
 			}
 			markFirstAccepted()
 			sessionID := conn.Permissions.Extensions["key_fp"] + "\x00" + resume.ResumeID
-			go func() { defer func() { <-chanSlots }(); serveShell(channel, requests, sessionID) }()
+			go func() {
+				defer func() { <-chanSlots }()
+				defer guardPanic("shell channel")
+				serveShell(channel, requests, sessionID)
+			}()
 		case directTCPIPChannelType:
-			go serveDirectTCPIP(newChannel, markFirstAccepted)
+			// Take a per-connection slot like the other channel types. Without
+			// this, direct-tcpip opens bypassed maxChannelsPerConn entirely and
+			// only the global tunnel cap applied — and that was acquired inside
+			// the goroutine, after the spawn, so a peer could still churn
+			// unbounded transient goroutines.
+			select {
+			case chanSlots <- struct{}{}:
+			default:
+				_ = newChannel.Reject(ssh.ResourceShortage, "too many concurrent channels")
+				continue
+			}
+			go func() {
+				defer func() { <-chanSlots }()
+				defer guardPanic("direct-tcpip channel")
+				serveDirectTCPIP(newChannel, markFirstAccepted)
+			}()
 		default:
 			_ = newChannel.Reject(ssh.UnknownChannelType, "unsupported channel type")
 		}

--- a/internal/core/filetransfer.go
+++ b/internal/core/filetransfer.go
@@ -132,6 +132,15 @@ func (a *App) resolveTransferOptions(server ServerRecord, opts FileTransferOptio
 	if resolved.ChunkSize > proto.MaxRawChunkBytes {
 		resolved.ChunkSize = proto.MaxRawChunkBytes
 	}
+	// A recursive directory transfer runs dirTransferConcurrency files at once
+	// and EACH file opens `Parallel` channels, so the peak channel count is the
+	// product. `parallel_streams` is operator-configurable with no upper bound,
+	// so without this clamp a high value would plan more channels than the agent
+	// accepts and the transfer would fail mid-flight with ResourceShortage
+	// ("too many concurrent channels") rather than simply running slower.
+	if maxParallel := transport.MaxChannelsPerConn / dirTransferConcurrency; resolved.Parallel > maxParallel {
+		resolved.Parallel = maxParallel
+	}
 	if server.Mode == transport.ModeReverse && !serverSupportsReverseMultiplex(server) {
 		// An agent that cannot accept controller-opened channels leaves the hub
 		// with one mutex-serialised channel, so parallel streams are impossible.

--- a/internal/core/jobs.go
+++ b/internal/core/jobs.go
@@ -181,6 +181,17 @@ func (s *JobStore) reserve(doc *jobsDocument) int {
 // leaves its /var/tmp file for the sweep). Returns the number of records removed.
 func (s *JobStore) Prune(cutoff time.Time, exec ExecFunc) (int, error) {
 	var removed int
+	// Collected under the lock, executed after it is released. Doing the remote
+	// deletions inline would hold a CROSS-PROCESS advisory lock across N
+	// sequential SSH round-trips, so one unreachable server could stall every
+	// other `fleet` invocation until the 10s lock timeout. The record removal is
+	// the part that needs to be atomic; the log cleanup is best-effort and its
+	// failures are already ignored.
+	type pendingDelete struct {
+		server  string
+		logfile string
+	}
+	var pending []pendingDelete
 	err := s.withWriteLock(func() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -190,11 +201,12 @@ func (s *JobStore) Prune(cutoff time.Time, exec ExecFunc) (int, error) {
 		}
 		var kept []JobRecord
 		removed = 0
+		pending = pending[:0]
 		for _, j := range doc.Jobs {
 			if j.Status == JobDone && !j.Finished.IsZero() && j.Finished.Before(cutoff) {
 				removed++
 				if exec != nil && j.Logfile != "" {
-					_, _, _ = exec(j.Server, "rm -f "+shellQuote(j.Logfile))
+					pending = append(pending, pendingDelete{server: j.Server, logfile: j.Logfile})
 				}
 				continue
 			}
@@ -204,12 +216,15 @@ func (s *JobStore) Prune(cutoff time.Time, exec ExecFunc) (int, error) {
 			return nil
 		}
 		doc.Jobs = kept
-		if err := s.write(doc); err != nil {
-			return err
-		}
-		return nil
+		return s.write(doc)
 	})
-	return removed, err
+	if err != nil {
+		return removed, err
+	}
+	for _, p := range pending {
+		_, _, _ = exec(p.server, "rm -f "+shellQuote(p.logfile))
+	}
+	return removed, nil
 }
 
 // maxJobLogBytes bounds how much of a job's remote logfile Tail reads into memory

--- a/internal/core/panicguard.go
+++ b/internal/core/panicguard.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package core
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+)
+
+// guardPanic contains a panic to the single goroutine that raised it.
+//
+// The controller daemon serves every agent in the fleet from one process, so an
+// unrecovered panic in a per-connection goroutine does not just drop that
+// agent's session — it terminates the daemon and takes the whole fleet's
+// control plane with it. Guarding the handlers that parse agent-supplied input
+// converts that worst case into one dropped connection plus a stack trace.
+//
+// This is defense in depth: the envelope decode paths are size-bounded and use
+// checked type assertions, so no reachable panic is known today.
+func guardPanic(what string) {
+	if r := recover(); r != nil {
+		fmt.Fprintf(os.Stderr, "fleet: recovered panic in %s: %v\n%s\n", what, r, debug.Stack())
+	}
+}

--- a/internal/core/redact.go
+++ b/internal/core/redact.go
@@ -22,7 +22,24 @@ var defaultSecretPatterns = []string{
 	`(?i)(password|passwd|pwd)\s*[:=]\s*\S+`,
 	`(?i)(secret|api[_-]?key|token)\s*[:=]\s*\S+`,
 	`(?i)authorization:\s*bearer\s+\S+`,
-	`-----BEGIN [A-Z ]*PRIVATE KEY-----`,
+	// Match the WHOLE PEM block, not just the BEGIN line. Go's regexp is
+	// line-oriented and `.` does not cross a newline without the `s` flag, so a
+	// header-only pattern masks the header and lets the base64 key body through
+	// verbatim — worse than no redaction, because it looks handled. `(?s)` makes
+	// `.` span newlines and the non-greedy `.*?` stops at the first END line so
+	// two concatenated keys are redacted separately rather than as one blob.
+	`(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`,
+	// Fallback for a truncated/unterminated key (no END line): the block pattern
+	// above cannot match, so still mask the header. Ordering matters — the block
+	// pattern runs first and consumes a complete key before this one is tried.
+	`(?i)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----`,
+	// High-specificity credential shapes. Each is narrow enough not to mangle
+	// ordinary output: AWS key IDs have a fixed prefix+length, a JWT has three
+	// base64url segments, and URL credentials require the `user:pass@` form.
+	`\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b`,
+	`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`,
+	`(?i)\b[a-z][a-z0-9+.-]*://[^\s:/@]+:[^\s/@]+@`,
+	`(?i)\bbearer\s+[A-Za-z0-9._~+/-]{16,}={0,2}`,
 }
 
 // RedactStore holds output-redaction policy, persisted as a single JSON

--- a/internal/core/redact_test.go
+++ b/internal/core/redact_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func defaultsEnabledStore(t *testing.T) *RedactStore {
+	t.Helper()
+	s, err := NewRedactStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewRedactStore: %v", err)
+	}
+	if err := s.SetDefaults(true); err != nil {
+		t.Fatalf("SetDefaults: %v", err)
+	}
+	return s
+}
+
+// The regression this guards: the default pattern used to match only the
+// `-----BEGIN ... KEY-----` header. Go's regexp is line-oriented, so the base64
+// body and END line passed through verbatim while the output *looked* redacted.
+func TestRedactMasksEntirePrivateKeyBlock(t *testing.T) {
+	s := defaultsEnabledStore(t)
+
+	const body = "MIIEowIBAAKCAQEAxSecretKeyMaterialThatMustNeverBeEmitted"
+	input := "before\n" +
+		"-----BEGIN RSA PRIVATE KEY-----\n" +
+		body + "\n" +
+		"AnotherLineOfKeyMaterial\n" +
+		"-----END RSA PRIVATE KEY-----\n" +
+		"after\n"
+
+	got := s.Redact(input)
+
+	if strings.Contains(got, body) {
+		t.Errorf("private key body leaked through redaction:\n%s", got)
+	}
+	if strings.Contains(got, "AnotherLineOfKeyMaterial") {
+		t.Errorf("private key body leaked through redaction:\n%s", got)
+	}
+	if strings.Contains(got, "-----END RSA PRIVATE KEY-----") {
+		t.Errorf("END line leaked through redaction:\n%s", got)
+	}
+	if !strings.Contains(got, RedactPlaceholder) {
+		t.Errorf("expected placeholder in output, got:\n%s", got)
+	}
+	// Surrounding output must survive — redaction should not swallow the stream.
+	if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+		t.Errorf("redaction removed surrounding output:\n%s", got)
+	}
+}
+
+// A key with no END line must still have its header masked; the block pattern
+// cannot match, so the header-only fallback has to catch it.
+func TestRedactMasksTruncatedPrivateKeyHeader(t *testing.T) {
+	s := defaultsEnabledStore(t)
+	got := s.Redact("-----BEGIN OPENSSH PRIVATE KEY-----\ntruncated")
+	if strings.Contains(got, "BEGIN OPENSSH PRIVATE KEY") {
+		t.Errorf("truncated key header not redacted: %q", got)
+	}
+}
+
+// Two concatenated keys must be redacted as two blocks, not merged into one
+// span that swallows whatever sits between them.
+func TestRedactHandlesTwoKeysNonGreedily(t *testing.T) {
+	s := defaultsEnabledStore(t)
+	input := "-----BEGIN EC PRIVATE KEY-----\naaa\n-----END EC PRIVATE KEY-----\n" +
+		"MIDDLE-MARKER\n" +
+		"-----BEGIN EC PRIVATE KEY-----\nbbb\n-----END EC PRIVATE KEY-----\n"
+	got := s.Redact(input)
+	if !strings.Contains(got, "MIDDLE-MARKER") {
+		t.Errorf("non-greedy match failed; text between keys was swallowed:\n%s", got)
+	}
+	if strings.Contains(got, "aaa") || strings.Contains(got, "bbb") {
+		t.Errorf("key material leaked:\n%s", got)
+	}
+}
+
+func TestRedactDefaultCredentialShapes(t *testing.T) {
+	s := defaultsEnabledStore(t)
+	cases := []struct {
+		name   string
+		input  string
+		secret string
+	}{
+		{"aws access key id", "key=AKIAIOSFODNN7EXAMPLE done", "AKIAIOSFODNN7EXAMPLE"},
+		{"jwt", "auth eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk done", "eyJhbGciOiJIUzI1NiJ9"},
+		{"url credentials", "https://admin:hunter2@example.com/path", "hunter2"},
+		{"bare bearer token", "Bearer abcdef0123456789abcdef", "abcdef0123456789abcdef"},
+		{"password assignment", "password: supersecretvalue", "supersecretvalue"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := s.Redact(tc.input)
+			if strings.Contains(got, tc.secret) {
+				t.Errorf("%s leaked: %q", tc.name, got)
+			}
+		})
+	}
+}
+
+// Redaction must be off unless explicitly enabled, and must not mangle ordinary
+// output when it is on.
+func TestRedactDefaultsOffAndNoFalsePositives(t *testing.T) {
+	off, err := NewRedactStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewRedactStore: %v", err)
+	}
+	const plain = "password: hunter2"
+	if got := off.Redact(plain); got != plain {
+		t.Errorf("defaults should be off until enabled, got %q", got)
+	}
+
+	s := defaultsEnabledStore(t)
+	ordinary := "total 24\ndrwxr-xr-x 2 root root 4096 Jan  1 00:00 etc\nhttps://example.com/path?a=1\nCPU 12%"
+	if got := s.Redact(ordinary); got != ordinary {
+		t.Errorf("ordinary output was mangled:\ngot:  %q\nwant: %q", got, ordinary)
+	}
+}

--- a/internal/core/reverse.go
+++ b/internal/core/reverse.go
@@ -255,6 +255,7 @@ func (h *ReverseHub) Serve(ctx context.Context, listener net.Listener) error {
 			var once sync.Once
 			releaseHandshake := func() { once.Do(func() { <-reverseHandshakeSlots }) }
 			defer releaseHandshake()
+			defer guardPanic("reverse agent connection")
 			_ = h.serveConnAfterAuth(conn, releaseHandshake)
 		}()
 	}
@@ -598,6 +599,7 @@ func (h *ReverseHub) ServeControl(ctx context.Context, listener net.Listener) er
 		case h.controlSlots <- struct{}{}:
 			go func() {
 				defer func() { <-h.controlSlots }()
+				defer guardPanic("control connection")
 				h.handleControlConn(conn)
 			}()
 		default:
@@ -824,6 +826,7 @@ func (h *ReverseHub) setSession(serverName string, session *transport.Session, i
 	if info.Hello.AgentVersion != "" && version.Canonical(info.Hello.AgentVersion) != version.Canonical(version.Version) &&
 		h.app.Config.Updates.Policy == update.PolicyAutoUpdate {
 		go func() {
+			defer guardPanic("agent auto-update")
 			_ = h.app.AuditLog.Append(logs.AuditEntry{
 				Action:   "agent.auto-update",
 				Target:   serverName,
@@ -1021,7 +1024,12 @@ func (a *App) readControlToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read control token: %w", err)
 	}
-	return string(data), nil
+	// Trim surrounding whitespace: the token is compared byte-for-byte with a
+	// constant-time compare, so a trailing newline introduced by an editor or a
+	// manual rewrite of the file would fail authentication with no useful
+	// diagnostic. generateControlToken writes no newline, so this is
+	// forward-compatible robustness, not a behavior change today.
+	return strings.TrimSpace(string(data)), nil
 }
 
 func validateLoopbackControlAddress(address string) error {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -24,6 +24,14 @@ const (
 	ModePerNode Mode = "per-server"
 )
 
+// MaxChannelsPerConn is the number of concurrent fleet-rpc/shell channels one
+// SSH connection may have open. The agent enforces it when accepting channel
+// opens, and the controller clamps its transfer concurrency against it so a
+// configured `parallel_streams` can never plan more channels than the peer will
+// accept. Keeping it here — rather than as a local const on each side — is what
+// makes the two limits provably consistent instead of coincidentally so.
+const MaxChannelsPerConn = 128
+
 func (m Mode) String() string {
 	return string(m)
 }

--- a/internal/webui/listcache_test.go
+++ b/internal/webui/listcache_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package webui
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cenvero/fleet/pkg/proto"
+)
+
+func newTestCache() *dirListCache {
+	return &dirListCache{entries: make(map[string]listCacheEntry)}
+}
+
+// The regression this guards: the cache was a sync.Map that was never evicted,
+// so a session browsing many directories grew it for the life of the process.
+// The cache key embeds the operator-supplied path, so its cardinality is
+// effectively unbounded.
+func TestListCacheStaysBounded(t *testing.T) {
+	c := newTestCache()
+	for i := 0; i < listCacheMaxEntries*4; i++ {
+		c.put(fmt.Sprintf("server\x00/dir/%d\x000", i), proto.FileListResult{})
+	}
+	c.mu.Lock()
+	got := len(c.entries)
+	c.mu.Unlock()
+	if got > listCacheMaxEntries {
+		t.Errorf("cache grew past its cap: got %d entries, cap %d", got, listCacheMaxEntries)
+	}
+}
+
+func TestListCacheRoundTripAndExpiry(t *testing.T) {
+	c := newTestCache()
+	const key = "srv\x00/tmp\x000"
+	c.put(key, proto.FileListResult{Path: "/tmp"})
+
+	got, ok := c.get(key)
+	if !ok {
+		t.Fatal("expected a cache hit immediately after put")
+	}
+	if got.Path != "/tmp" {
+		t.Errorf("cached wrong value: %+v", got)
+	}
+
+	// Force expiry rather than sleeping for the real TTL.
+	c.mu.Lock()
+	c.entries[key] = listCacheEntry{result: got, expires: time.Now().Add(-time.Second)}
+	c.mu.Unlock()
+
+	if _, ok := c.get(key); ok {
+		t.Error("expected a miss for an expired entry")
+	}
+	// An expired entry must be dropped on access, not merely skipped — that is
+	// what stops expired keys accumulating.
+	c.mu.Lock()
+	n := len(c.entries)
+	c.mu.Unlock()
+	if n != 0 {
+		t.Errorf("expired entry was not evicted on access: %d entries remain", n)
+	}
+}
+
+func TestListCacheInvalidateClearsEverything(t *testing.T) {
+	c := newTestCache()
+	c.put("a\x00/1\x000", proto.FileListResult{})
+	c.put("b\x00/2\x000", proto.FileListResult{})
+	c.invalidate()
+	c.mu.Lock()
+	n := len(c.entries)
+	c.mu.Unlock()
+	if n != 0 {
+		t.Errorf("invalidate left %d entries", n)
+	}
+	if _, ok := c.get("a\x00/1\x000"); ok {
+		t.Error("expected a miss after invalidate")
+	}
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -190,6 +190,13 @@ func (s *Server) guard(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 		next(w, r)
+		// Every mutating endpoint is a POST, so this is the one place that
+		// catches them all — including /api/upload, which enforces POST itself
+		// rather than going through postOnly. Without this a create/delete could
+		// stay invisible (or a deleted file keep showing) for the cache TTL.
+		if r.Method == http.MethodPost {
+			listCache.invalidate()
+		}
 	}
 }
 
@@ -262,33 +269,26 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 		hs = "1"
 	}
 	cacheKey := server + "\x00" + dir + "\x00" + hs
-	if v, ok := listCache.Load(cacheKey); ok {
-		c := v.(cachedList)
-		if time.Now().Before(c.expires) {
-			if c.err != nil {
-				writeError(w, c.err)
-				return
-			}
-			writeJSON(w, c.result)
-			return
-		}
+	if result, ok := listCache.get(cacheKey); ok {
+		writeJSON(w, result)
+		return
 	}
 	if server == "" {
 		result, err := listLocalDir(dir, showHidden)
-		listCache.Store(cacheKey, cachedList{result: result, err: err, expires: time.Now().Add(400 * time.Millisecond)})
 		if err != nil {
 			writeError(w, err)
 			return
 		}
+		listCache.put(cacheKey, result)
 		writeJSON(w, result)
 		return
 	}
 	result, err := s.app.ListRemoteDirHidden(server, dir, showHidden)
-	listCache.Store(cacheKey, cachedList{result: result, err: err, expires: time.Now().Add(400 * time.Millisecond)})
 	if err != nil {
 		writeError(w, err)
 		return
 	}
+	listCache.put(cacheKey, result)
 	writeJSON(w, result)
 }
 
@@ -306,19 +306,75 @@ func cleanLocalPath(p string) (string, error) {
 	return filepath.Clean(p), nil
 }
 
-var listCache sync.Map // listCacheKey -> cachedList
-//lint:ignore U1000 listCacheKey is used as sync.Map key (fields via struct literal)
-type listCacheKey struct {
-	server string
-	dir    string
-	hidden bool
+// listCacheTTL is deliberately short: it exists only to collapse the burst of
+// duplicate /api/list calls the UI makes when a pane repaints, not to serve
+// stale data. listCacheMaxEntries hard-caps memory — the cache key embeds the
+// operator-supplied `path`, so without a ceiling a session that browses many
+// directories would grow the map for the life of the process.
+const (
+	listCacheTTL        = 400 * time.Millisecond
+	listCacheMaxEntries = 512
+)
+
+type listCacheEntry struct {
+	result  proto.FileListResult
+	expires time.Time
 }
 
-var _ = listCacheKey{} // ensure type is used for staticcheck
-type cachedList struct {
-	result  proto.FileListResult
-	err     error
-	expires time.Time
+// dirListCache is a bounded, self-evicting TTL cache for directory listings.
+// Only successful listings are cached: caching an error would replay a transient
+// SSH failure for the whole TTL window.
+type dirListCache struct {
+	mu      sync.Mutex
+	entries map[string]listCacheEntry
+}
+
+var listCache = &dirListCache{entries: make(map[string]listCacheEntry)}
+
+func (c *dirListCache) get(key string) (proto.FileListResult, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return proto.FileListResult{}, false
+	}
+	if !time.Now().Before(e.expires) {
+		// Drop on access so expired keys cannot accumulate indefinitely.
+		delete(c.entries, key)
+		return proto.FileListResult{}, false
+	}
+	return e.result, true
+}
+
+func (c *dirListCache) put(key string, result proto.FileListResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for k, e := range c.entries {
+		if !now.Before(e.expires) {
+			delete(c.entries, k)
+		}
+	}
+	// If a burst of distinct live keys still exceeds the cap, evict until under
+	// it. Map iteration order is randomized, so this is an arbitrary-victim
+	// policy — acceptable for a 400ms cache, and it bounds memory absolutely.
+	for k := range c.entries {
+		if len(c.entries) < listCacheMaxEntries {
+			break
+		}
+		delete(c.entries, k)
+	}
+	c.entries[key] = listCacheEntry{result: result, expires: now.Add(listCacheTTL)}
+}
+
+// invalidate clears the whole cache after any mutating request. A mutation can
+// affect a directory other than the one named (a copy/move touches its
+// destination, possibly on another server), so clearing everything is correct
+// where per-key invalidation would miss those.
+func (c *dirListCache) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	clear(c.entries)
 }
 
 // gzipHandler compresses responses when the client accepts gzip and the
@@ -348,10 +404,25 @@ func gzipHandler(next http.Handler) http.Handler {
 
 type gzipResponseWriter struct {
 	http.ResponseWriter
-	Writer io.Writer
+	Writer *gzip.Writer
 }
 
 func (g *gzipResponseWriter) Write(b []byte) (int, error) { return g.Writer.Write(b) }
+
+// Flush keeps the wrapper transparent to streaming handlers: without it the
+// embedded ResponseWriter's Flush would push the compressor's *unflushed* buffer
+// nowhere, so a streaming response wrapped in gzip would stall. Flushing the
+// gzip writer first guarantees the bytes reach the client.
+func (g *gzipResponseWriter) Flush() {
+	_ = g.Writer.Flush()
+	if f, ok := g.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap lets net/http (and ResponseController) reach the underlying writer for
+// capabilities this wrapper does not implement.
+func (g *gzipResponseWriter) Unwrap() http.ResponseWriter { return g.ResponseWriter }
 
 // resolveLocalWritePath canonicalizes a local write/create target so an attacker
 // cannot use a symlinked INTERMEDIATE directory to redirect the create/truncate


### PR DESCRIPTION
Full-tree security audit follow-up. **No CRITICAL or HIGH vulnerabilities were found** — these are the MEDIUM and LOW items, plus tests.

## The finding that mattered

`internal/core/redact.go` — the default private-key pattern matched only the `-----BEGIN ... PRIVATE KEY-----` **header**. Go's `regexp` is line-oriented and `.` does not cross newlines without `(?s)`, so the base64 key body and END line passed through **verbatim** while the output looked redacted. With `redact-defaults on`, `fleet exec host -- cat /etc/ssl/private/server.key` emitted the whole key with only its header masked — worse than no redaction, because it appears handled.

Fixed by matching the whole PEM block non-greedily, with a header-only fallback so a truncated key is still masked. Defaults also broadened with high-specificity shapes (AWS key IDs, JWTs, `scheme://user:pass@host`, bare bearer tokens).

## Availability / blast radius

- **Panic guards** on the network-facing goroutines in the agent (connection, rpc, shell, direct-tcpip) and the controller reverse hub (agent connection, control connection, auto-update). An unrecovered panic in *any* goroutine kills the process, so a latent bug reachable from untrusted input could drop an agent — or the daemon serving the entire fleet. No reachable panic is known today; this is containment.
- **`direct-tcpip` now takes a per-connection channel slot** like every other channel type. It previously bypassed `maxChannelsPerConn` entirely, and the global tunnel cap was acquired *after* the goroutine spawned.
- **`JobStore.Prune` no longer holds the cross-process advisory lock across N sequential SSH deletions.** One unreachable server could previously stall other `fleet` invocations until the 10s lock timeout. Record removal stays atomic; the best-effort log cleanup moved out of the critical section.

## Web UI

- **Bounded the listing cache.** It was a `sync.Map` that was never evicted — the key embeds the operator-supplied `path`, so a session browsing many directories grew it for the life of the process, each entry holding a full directory listing. Now bounded with sweep-on-write and evict-on-access.
- **Stopped caching errors**, which replayed a transient SSH failure for the whole TTL.
- **Invalidate after any mutating POST**, so a create/delete can't stay invisible behind a stale listing. Hooked in `guard` because `/api/upload` enforces POST itself rather than going through `postOnly`.
- Removed a dead `listCacheKey` struct and its inaccurate lint directive; gave the gzip wrapper `Flush`/`Unwrap` so it stays transparent to streaming handlers.

## Transport / supply chain

- **`transport.MaxChannelsPerConn`** is now shared, and transfer concurrency clamps against it. `dirTransferConcurrency x parallel_streams` is the peak channel count and `parallel_streams` is operator-configurable with no upper bound, so a high value previously failed mid-transfer with `ResourceShortage` instead of just running slower.
- **Sign `checksums.txt`**, not just the archives.
- **Trim the control token on read** so a trailing newline can't silently break auth.

## Verification

`go build ./...`, `go vet ./...`, full `go test ./...` (12 packages), `go test -race` on the changed packages, and `gosec -severity=medium` — all clean. New tests: `internal/core/redact_test.go` (proves the key body is masked, non-greedy across two keys, and no false positives on ordinary output) and `internal/webui/listcache_test.go` (proves the bound holds, expiry evicts, invalidate clears).

## Deliberately not changed

- **`--file-root` default** stays unrestricted — tightening it is a breaking behavioral change for existing deployments.
- **`EnrollSecret` at rest** stays cleartext — hashing it needs a persistence migration.
- **Web UI token in the browser-opener argv** — the fix needs a token-handoff redesign, not a patch.
- **Remote `tar`/`unzip` extraction** — `--no-absolute-names` is GNU-only and would break the macOS/BSD targets this tool manages. Both GNU and BSD tar already reject `..` members by default.
- **Agent privilege dropping** and the unconfined Local pane are by-design for a fleet manager.