### PR TITLE
docs(site): document end-to-end agent deployment and multi-server control

### DIFF
--- a/public/agentic.html
+++ b/public/agentic.html
@@ -68,6 +68,21 @@
       },
       {
         "@type": "Question",
+        "name": "Can an AI agent handle a full deployment end to end?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Yes. The whole path is one self-describing CLI, so the agent never leaves the tool. It ships the build with 'fleet file upload' (chunked, parallel, resumable, checksummed), unpacks it with 'fleet file extract', renders config with 'fleet template' and injects credentials with 'fleet secret', restarts the unit with 'fleet service restart', then verifies with 'fleet svc status', 'fleet logs' and 'fleet exec' health checks. Long steps run detached as 'fleet job' so the agent polls for completion instead of holding a connection open. Every command returns JSON, so the agent branches on real results rather than scraped text." }
+      },
+      {
+        "@type": "Question",
+        "name": "Can one AI agent manage multiple servers at once?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Yes. 'fleet exec --all' fans a command out across the whole fleet and 'fleet exec --group role=web' targets a tag expression, so a single instruction can drive an entire tier and return per-server JSON. 'fleet tag' defines the groups, 'fleet file diff --group' compares a config file across a group, and 'fleet top', 'fleet status' and 'fleet report' give the agent fleet-wide state. File transfers address one server at a time, so the agent iterates over its targets for the upload step." }
+      },
+      {
+        "@type": "Question",
+        "name": "What stops an AI agent from breaking production during an unattended deploy?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Several controller-side rails, none of which depend on the agent behaving well. 'fleet guard' runs a risky command behind a dead-man's switch: a detached server-side timer reverts it unless the change is explicitly confirmed, so an agent that locks itself out recovers automatically. '--dry-run' prints what would run without running it, '--require-approval' stages a command for a human instead of executing it, and '--idempotency-key' returns the cached result for a key so a retrying agent cannot apply the same change twice. Scoped tokens are fail-closed, destructive commands need an explicit opt-in, and 'fleet drift' detects config that has moved away from a captured baseline." }
+      },
+      {
+        "@type": "Question",
         "name": "Does Cenvero Fleet require a cloud account?",
         "acceptedAnswer": { "@type": "Answer", "text": "No. Cenvero Fleet is fully self-hosted. A single binary is the controller; it connects to your servers over an encrypted, host-key-pinned channel and auto-installs agents. Agents can also dial out to the controller, so hosts behind NAT need no inbound access. There is no SaaS, no cloud account, and no telemetry in the core runtime." }
       }
@@ -202,6 +217,9 @@
     <div class="card"><h3>Can Claude control my servers over SSH?</h3><p>Yes. <code>fleet skill claude</code> installs a <code>/fleet</code> command; typing it makes the agent run <code>fleet context</code> and operate your servers over an authenticated, host-key-pinned SSH channel with your keys, on your machine. No cloud control plane.</p></div>
     <div class="card"><h3>How does an AI agent learn the CLI?</h3><p>From the binary itself. <code>fleet context</code> prints the full reference and <code>fleet ai &lt;command&gt;</code> gives complete per-command help — both generated live, so they always match your version.</p></div>
     <div class="card"><h3>Is it safe to let an agent operate it?</h3><p>The controller never trusts agent-provided paths for local writes, the agent can be confined with <code>--file-root</code>, updates require signed binaries, and destructive actions prompt for confirmation.</p></div>
+    <div class="card"><h3>Can an agent run a whole deployment end to end?</h3><p>Yes — the entire path is one CLI, so the agent never leaves the tool. It ships the build with <code>fleet file upload</code> (chunked, parallel, resumable, checksummed), unpacks with <code>fleet file extract</code>, renders config via <code>fleet template</code> and <code>fleet secret</code>, restarts with <code>fleet service restart</code>, then proves it worked with <code>fleet svc status</code>, <code>fleet logs</code> and <code>fleet exec</code> health checks. Slow steps run detached as <code>fleet job</code>, so the agent polls instead of holding a connection.</p></div>
+    <div class="card"><h3>Can one agent manage many servers at once?</h3><p><code>fleet exec --all</code> fans out across the fleet and <code>fleet exec --group role=web</code> targets a tag expression, so one instruction drives a whole tier and returns per-server JSON. <code>fleet tag</code> defines the groups, <code>fleet file diff --group</code> compares a config across them, and <code>fleet top</code> / <code>fleet status</code> give fleet-wide state. Transfers are per-server, so the agent iterates its targets for the upload step.</p></div>
+    <div class="card"><h3>What stops an agent breaking prod unattended?</h3><p>Rails that don't depend on the agent behaving. <code>fleet guard</code> runs a risky command behind a dead-man's switch — a detached server-side timer reverts it unless confirmed, so an agent that locks itself out recovers on its own. <code>--dry-run</code> shows the command without running it, <code>--require-approval</code> hands it to a human, and <code>--idempotency-key</code> makes a retry return the cached result instead of applying twice.</p></div>
     <div class="card"><h3>Does it need the cloud?</h3><p>No. Fleet is fully self-hosted — one binary, SSH to your servers, no SaaS and no telemetry in the core runtime.</p></div>
   </div>
 </section>

--- a/public/index.html
+++ b/public/index.html
@@ -524,6 +524,7 @@
     <button onclick="copyCmd(this,'fleet skill claude')">copy</button>
   </div>
   <p class="section-sub" style="margin-top:18px">Self-describing by design: <code>fleet context</code> and <code>fleet ai &lt;command&gt;</code> generate full, machine-readable help straight from the command tree — always in sync with the installed version, nothing to maintain by hand.</p>
+  <p class="section-sub" style="margin-top:18px"><strong>Whole deployments, not just single commands.</strong> An agent can carry a release end to end without leaving the CLI: upload the build (chunked, parallel, resumable), extract it, render config from templates and secrets, restart the service, then verify with status, logs and health checks — fanning out across the whole fleet with <code>fleet exec --all</code> or one tier with <code>--group role=web</code>. Long steps detach as jobs it can poll, and <code>fleet guard</code> arms a dead-man's switch that auto-reverts a risky change unless it's confirmed, so an unattended agent that locks itself out recovers on its own.</p>
   <div class="hero-actions" style="margin-top:26px">
     <a href="/agentic.html" class="btn btn-primary">Why Fleet is the best agentic SSH tool →</a>
   </div>


### PR DESCRIPTION
## Problem

The site explains that an AI agent can *learn* and *drive* the CLI, but never that it can carry a **whole release** on its own. The most common question a visitor arrives with — "can the agent actually deploy, or does it just run commands?" — had no answer anywhere on the page. Nothing described fleet-wide fan-out, and nothing addressed the obvious objection to letting an agent near production unattended.

## Why it matters

`agentic.html` is the page that argues Fleet is the best tool for agentic SSH, and it was under-selling the product's strongest capability while leaving the biggest trust objection unanswered. The FAQ is also the page's rich-results surface, so missing questions are missing search coverage for exactly the queries this page targets.

## Fix

Three FAQ entries added to `public/agentic.html` — in **both** the visible card grid and the JSON-LD `FAQPage` schema, kept in sync so the answers stay eligible for rich results — plus a paragraph in the `public/index.html` AI section so the landing page makes the same point:

1. **End-to-end deployment** — upload (chunked, parallel, resumable, checksummed) → `file extract` → `template` + `secret` → `service restart` → verify with `svc status`, `logs`, `exec` health checks, with slow steps detached as pollable `job`s.
2. **Multi-server** — `exec --all` and `exec --group role=web` fan out and return per-server JSON; `tag` defines the groups; `file diff --group` compares a config across one.
3. **Unattended safety** — `guard`'s dead-man switch auto-reverts an unconfirmed risky change, plus `--dry-run`, `--require-approval`, and `--idempotency-key` so a retrying agent cannot apply the same change twice.

## Accuracy

Every claim was verified against the actual command tree instead of written as marketing copy. Two things are **deliberately not claimed**:

- `file upload` and `sync` take a single `<server>` — there is no `--group` fan-out for transfers, so the copy says the agent iterates its targets for the upload step.
- `fleet rollback` restores the **controller binary** after an update, so it is not described as deployment rollback.

## Tests

N/A — static marketing HTML, no test suite covers it. Verified instead by:

- Parsing both `<script type="application/ld+json">` blocks with `json.loads` — valid, `FAQPage` now carries 7 questions (was 4).
- Running both files through `html.parser` with a tag-balance check — 0 errors, 0 unclosed tags.

## Manual verification

Served `public/` on loopback (`127.0.0.1`) and confirmed `agentic.html` and `index.html` both return HTTP 200 after the edit.

No screenshots: the change is copy inside existing, already-styled `.card` and `.section-sub` containers — it introduces no new components, layout, or CSS.