### PR TITLE
fix(release): stop signing checksums.txt, which broke the v2.4.0 release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,19 +62,13 @@ signs:
       - "${artifact}"
       - "${signature}"
       - "{{ .Env.MINISIGN_KEY_FILE }}"
-  # Sign the aggregate checksum manifest too. Each archive already carries its
-  # own .minisig, so per-artifact integrity was covered, but an unsigned
-  # checksums.txt is a tampering surface for anyone who verifies via the
-  # manifest instead of the individual signatures.
-  - id: bound-checksum-signature
-    artifacts: checksum
-    cmd: ./scripts/sign-release-artifact.sh
-    signature: "${artifact}.minisig"
-    stdin: "{{ .Env.MINISIGN_PASSWORD }}"
-    args:
-      - "${artifact}"
-      - "${signature}"
-      - "{{ .Env.MINISIGN_KEY_FILE }}"
+  # NOTE: checksums.txt is deliberately NOT signed here. sign-release-artifact.sh
+  # only accepts `<product>_<version>_<os>_<arch>.(tar.gz|zip)` because it derives
+  # the minisign trusted comment from those fields, so pointing it at
+  # checksums.txt fails the release with "unrecognized release name". Signing the
+  # manifest needs the signer to take an explicit version argument first; until
+  # then per-archive .minisig files remain the integrity mechanism the installers
+  # actually verify.
 
 homebrew_casks:
   - name: cenvero-fleet


### PR DESCRIPTION
## Problem

The **v2.4.0 release failed**. GoReleaser aborted before publishing anything:

```
⨯ release failed after 4m20s
  error=exit status 1
  message=could not sign artifact cmd=./scripts/sign-release-artifact.sh artifact=checksums.txt
  │ refusing to sign artifact with an unrecognized release name: checksums.txt
```

No GitHub release, no manifest update, no Pages deploy — the `Update manifest`, `Smoke test release` and `Deploy Pages` jobs were all skipped. Run: https://github.com/cenvero/fleet/actions/runs/31425471384

## Root cause

A recent change added a second `signs:` entry with `artifacts: checksum` so `checksums.txt` would be signed alongside the archives. But `scripts/sign-release-artifact.sh` accepts **only**:

```
<product>_<version>_<os>_<arch>.(tar.gz|zip)
```

It parses `product`, `version` and `target` out of the filename to build the minisign trusted comment (`cenvero-fleet ${product} v${version} ${target}`). `checksums.txt` matches none of that, so the signer refuses it — and because signing is part of the release step, the whole release aborts. The mistake was adding the config without checking the signer's accepted-name contract.

## Fix

Revert the `artifacts: checksum` entry, restoring the release pipeline to its previously-working shape, and leave a comment in `.goreleaser.yml` explaining why it is absent so it is not re-added blindly.

**Security value lost is small.** Every archive still carries its own `.minisig`, and that per-archive signature — not the checksum manifest — is what `public/install.sh` and `public/install.ps1` actually verify (both refuse to proceed without a valid minisign signature).

**Why not fix it forward instead:** signing the manifest properly needs `sign-release-artifact.sh` to accept an explicit version argument (GoReleaser can pass `{{ .Version }}`) plus a trusted-comment format for an artifact that has no product/target. That is a change to security-critical signing code and belongs in its own reviewed, smoke-tested commit — not in a hotfix to an already-broken release.

## Tests

`./scripts/test-release-tools.sh` passes — signing assets sync, release env validation, manifest generation, and the complete signed 14-artifact matrix all verify.

## Manual verification

Confirmed the `signs:` block now has exactly one entry (`artifacts: archive`) and that `gh release view v2.4.0` reports "release not found", i.e. the failed run published nothing that needs cleaning up.

## Follow-up

Re-cut v2.4.0 once this lands. Signing `checksums.txt` can be revisited as its own change.