### PR TITLE
fix(release): publish a Homebrew formula, not a cask

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,22 +70,55 @@ signs:
   # then per-archive .minisig files remain the integrity mechanism the installers
   # actually verify.
 
-homebrew_casks:
+# Homebrew: we publish a FORMULA, not a Cask, and that is deliberate.
+#
+# Our macOS binaries are not Apple-notarized (notarization needs a paid Apple
+# Developer account). Homebrew treats the two package types differently:
+#
+#   - Casks are downloaded with the `com.apple.quarantine` attribute set, so
+#     Gatekeeper runs its notarization check and blocks an un-notarized binary
+#     with "Apple could not verify 'fleet' is free of malware". v2.4.0 shipped
+#     as a Cask and hit exactly this.
+#   - Formulae are fetched with plain curl, which never sets that attribute, so
+#     Gatekeeper does not run and the binary launches. This is how essentially
+#     every un-notarized CLI tool is distributed.
+#
+# GoReleaser deprecated `brews` in v2.10 in favour of `homebrew_casks`, so this
+# block emits a deprecation warning. That is accepted on purpose: per
+# GoReleaser's own policy deprecated options are only removed on a major
+# version, and a warning is preferable to shipping a package macOS refuses to
+# run. Do NOT "fix" the warning by switching back to homebrew_casks.
+#
+# Bring the Cask back only once ONE of these is true:
+#   1. The darwin builds are codesigned + notarized with an Apple Developer ID
+#      (see the `notarize` section in GoReleaser's docs), or
+#   2. fleet is accepted into homebrew-core, where Homebrew's own CI builds the
+#      bottles and neither a Cask nor a certificate is needed.
+#
+# Note also that Homebrew is actively removing the escape hatches here: as of
+# Homebrew 5.0.0 the `--no-quarantine` flag is deprecated and un-codesigned
+# casks in homebrew-cask are scheduled to be disabled. Stripping the quarantine
+# bit in a post-install hook is therefore a dead end, not a fix.
+brews:
   - name: cenvero-fleet
-    ids: [fleet-archive]
-    binaries: [fleet]
+    ids:
+      - fleet-archive
     repository:
       owner: cenvero
       name: homebrew-fleet
       token: "{{ .Env.HOMEBREW_TOKEN }}"
-    homepage: https://fleet.cenvero.org
-    description: Self-hosted decentralized fleet management platform
-    license: AGPL-3.0-or-later
-    directory: Casks
+    homepage: "https://fleet.cenvero.org"
+    description: "Self-hosted decentralized fleet management platform"
+    license: "AGPL-3.0-or-later"
+    directory: Formula
     skip_upload: auto
     commit_author:
       name: cenvero-bot
       email: 276044322+cenvero-bot@users.noreply.github.com
+    install: |
+      bin.install "fleet"
+    test: |
+      assert_match version.to_s, shell_output("#{bin}/fleet --version")
 
 release:
   draft: false


### PR DESCRIPTION
## Problem

**v2.4.0 cannot be run after installing from Homebrew.** It was the first release published after the switch to `homebrew_casks`, and macOS blocks it:

```
"fleet" Not Opened
Apple could not verify "fleet" is free of malware that may harm your Mac
or compromise your privacy.
```

## Why it matters

Every macOS user who installs v2.4.0 via Homebrew gets a binary that will not launch. There is no workaround we can reasonably ask users to run — telling people to `xattr` their way past Gatekeeper is not an install instruction.

## Fix (symptom → root cause → change)

Fleet's darwin binaries are **not Apple-notarized** (notarization requires a paid Apple Developer account). Homebrew handles the two package types differently, and that difference is the whole bug:

- **Casks** are downloaded with `com.apple.quarantine` set → Gatekeeper runs its notarization check → un-notarized binary is refused.
- **Formulae** are fetched with plain curl, which never sets that attribute → Gatekeeper does not run → the binary launches.

v2.3.0 shipped as a **formula** and ran fine. v2.4.0 shipped as a **cask** and is blocked. Same unsigned binary; the package type was the only variable.

So: restore the `brews:` block — restored verbatim from `56fdfee^`, the config that was working before the switch — and document why it has to stay.

## Deliberate decisions recorded in the comment

- **The deprecation warning is accepted on purpose.** GoReleaser deprecated `brews` in v2.10. Per GoReleaser's own policy, deprecated options are only removed on a major version, so it remains functional across v2.x. A warning is preferable to shipping a package macOS refuses to run. The comment says explicitly not to "fix" the warning by reverting to `homebrew_casks`.
- **Not using a quarantine-stripping post-install hook.** It bypasses a macOS security control rather than satisfying it, and Homebrew is removing that path: 5.0.0 deprecated `--no-quarantine` because *"Homebrew does not wish to easily provide circumvention to macOS security features"*, and un-codesigned casks in homebrew-cask are scheduled for disabling. GoReleaser also warns Apple may disable the bypass.
- **When a cask becomes correct again:** darwin builds notarized with an Apple Developer ID, or fleet accepted into homebrew-core (where Homebrew's CI builds the bottles and no certificate is involved).

## Tests

N/A — release configuration; no test suite covers it. Verified instead:

- `goreleaser check` (v2.17.1) reports **"configuration is valid, but uses deprecated properties"** — valid config, non-zero exit purely from the deprecation.
- Confirmed **no workflow runs `goreleaser check`**, so nothing in CI gates on that exit code. `goreleaser release` warns and proceeds.
- Confirmed no `homebrew_casks:` block remains.

## Manual verification

The tap has already been brought in line by hand so users aren't stuck waiting on the next release — https://github.com/cenvero/homebrew-fleet/pull/1: `Casks/` removed, `Formula/cenvero-fleet.rb` bumped to v2.4.0 with hashes taken from the release's `checksums.txt` (`ruby -c` clean), and the rationale recorded in the tap README.

Note that while both files existed they were both named `cenvero-fleet`, and Homebrew resolves a formula before a cask — so `brew install cenvero-fleet` was silently installing the stale v2.3.0 formula instead of the v2.4.0 cask. Removing the cask resolves that too.