### PR TITLE
fix(security): bump Go to 1.26.6, x/crypto to 0.56.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cenvero/fleet
 
-go 1.26.5
+go 1.26.6
 
 require (
 	aead.dev/minisign v0.3.0
@@ -16,7 +16,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/mod v0.40.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2wtOnGAHZWCHUM4KGzY=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:j/pmGrbnkbPtQfxEe5D0VQhZC6qKbfKifgD0oM7sR70=
 golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=


### PR DESCRIPTION
## Why

The CI \`Security\` job (govulncheck) has been failing on every recent PR due to pre-existing vulnerabilities unrelated to those PRs' actual changes:

- 7 stdlib CVEs in Go 1.26.5 (fixed in 1.26.6), including an `encoding/asn1` stack-exhaustion DoS reachable via `crypto.LoadPrivateKeySigner` → `ssh.ParsePrivateKeyWithPassphrase`, and a punycode/idna validation bypass reachable via `core.NotifyStore.Send` → `http.Client.Do`.
- 2 SSH DoS CVEs in `golang.org/x/crypto` 0.55.0 (GO-2026-6354, GO-2026-6355), fixed in 0.56.0 — a malicious peer can deadlock an established or undecided SSH channel. Directly reachable from this project's transport layer (`ssh.Dial`, `ssh.NewClientConn`, `ssh.NewServerConn` — both direct and reverse mode).

## Changes

- `go.mod`: `go 1.26.5` → `go 1.26.6`
- `go.mod`/`go.sum`: `golang.org/x/crypto` `v0.55.0` → `v0.56.0`

## Testing

All verified locally:
- `govulncheck ./...` → 0 vulnerabilities (previously 7)
- `gosec ./...` → 0 issues
- `gofmt`, `go vet`, `staticcheck`, `go mod tidy` → clean
- `go test -race -cover ./...` → all packages pass