### PR TITLE
fix(installer): support clean Windows installs

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -1,0 +1,74 @@
+name: installer-smoke
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: installer-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  posix-installer:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux installer (Ubuntu)
+            runner: ubuntu-latest
+          - name: macOS installer
+            runner: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install verifier dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y jq minisign
+
+      - name: Install verifier dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          for formula in jq minisign; do
+            brew list --versions "${formula}" >/dev/null 2>&1 || brew install "${formula}"
+          done
+
+      - name: Install and run the real signed release
+        run: ./scripts/test-posix-installer.sh
+
+  windows-installer:
+    name: Windows installer (${{ matrix.name }})
+    runs-on: windows-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows PowerShell 5.1
+            executable: powershell.exe
+            major: 5
+          - name: PowerShell 7
+            executable: pwsh.exe
+            major: 7
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install and run the real signed release
+        shell: powershell
+        run: |
+          & "${{ matrix.executable }}" -NoLogo -NoProfile -ExecutionPolicy Bypass `
+            -File .\scripts\test-windows-installer.ps1 `
+            -ExpectedMajor ${{ matrix.major }}
+          if ($LASTEXITCODE -ne 0) {
+            throw "installer smoke test failed with exit code $LASTEXITCODE"
+          }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ For the public one-command installer entrypoint:
 curl -fsSL https://fleet.cenvero.org/install | sh
 ```
 
-The `install` entrypoint dispatches to the correct hosted installer for the detected platform. On Linux and macOS it runs the POSIX installer directly. From a Windows-compatible shell such as Git Bash or WSL, it hands off to the PowerShell installer.
+For native Windows PowerShell 5.1 or later:
+
+```powershell
+irm https://fleet.cenvero.org/install.ps1 | iex
+```
+
+The Windows installer automatically downloads a checksum-pinned official `minisign` verifier when one is not already installed, then verifies the Fleet archive signature and checksum before installing it.
+
+The `install` entrypoint dispatches to the correct hosted installer for the detected platform. On Linux and macOS it runs the POSIX installer directly. From a Windows-compatible shell such as Git Bash, it hands off to the PowerShell installer.
 
 ## Build From Source
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,15 @@ For the public installer entrypoint:
 curl -fsSL https://fleet.cenvero.org/install | sh
 ```
 
-That command resolves to the hosted installer for the detected platform. On Linux and macOS it runs the POSIX installer. From a Windows-compatible shell such as Git Bash or WSL, it hands off to the PowerShell installer.
+For native Windows PowerShell 5.1 or later:
+
+```powershell
+irm https://fleet.cenvero.org/install.ps1 | iex
+```
+
+The Windows installer automatically downloads a checksum-pinned official `minisign` verifier when needed, then verifies the Fleet archive signature and checksum before installation.
+
+The cross-platform command resolves to the hosted installer for the detected platform. On Linux and macOS it runs the POSIX installer. From a Windows-compatible shell such as Git Bash, it hands off to the PowerShell installer.
 
 ## Build the Binaries
 

--- a/public/install.ps1
+++ b/public/install.ps1
@@ -7,6 +7,18 @@ $VersionOverride = $env:FLEET_VERSION
 $MinisignPublicKey = "RWRb53p9WTsWCO2RZT3bvjrZw4QjXnIo2R7NUqhPsfvhR8u0sS55hZb3"
 $ApprovedHosts = @("fleet.cenvero.org", "github.com", "release-assets.githubusercontent.com", "objects.githubusercontent.com")
 
+# A clean Windows installation does not include minisign. Bootstrap the official
+# verifier from an immutable release URL and authenticate the archive before
+# executing it. Update the URL, size, and digest together when upgrading.
+$MinisignBootstrapUrl = "https://github.com/jedisct1/minisign/releases/download/0.12/minisign-0.12-win64.zip"
+$MinisignBootstrapSize = 252505L
+$MinisignBootstrapSha256 = "37b600344e20c19314b2e82813db2bfdcc408b77b876f7727889dbd46d539479"
+
+# Windows PowerShell 5.1 does not reliably load these assemblies on first use.
+# Load them before any HttpClient or ZipFile type is resolved.
+Add-Type -AssemblyName System.Net.Http -ErrorAction Stop
+Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+
 function Test-ForbiddenAddress([System.Net.IPAddress] $Address) {
   if ($Address.IsIPv4MappedToIPv6) { $Address = $Address.MapToIPv4() }
   if ([System.Net.IPAddress]::IsLoopback($Address) -or $Address.Equals([System.Net.IPAddress]::Any) -or $Address.Equals([System.Net.IPAddress]::IPv6Any)) { return $true }
@@ -54,7 +66,7 @@ function Get-ApprovedFile([string] $Url, [string] $OutFile) {
       try {
         if ($response.StatusCode -eq [System.Net.HttpStatusCode]::OK) {
           $stream = [System.IO.File]::Create($OutFile)
-          try { $response.Content.CopyToAsync($stream).GetAwaiter().GetResult() } finally { $stream.Dispose() }
+          try { [void]$response.Content.CopyToAsync($stream).GetAwaiter().GetResult() } finally { $stream.Dispose() }
           return
         }
         if ([int]$response.StatusCode -notin @(301, 302, 303, 307, 308)) { throw "Unexpected download HTTP status: $($response.StatusCode)" }
@@ -70,18 +82,55 @@ function Get-ApprovedFile([string] $Url, [string] $OutFile) {
   finally { $client.Dispose(); $handler.Dispose() }
 }
 
+function Resolve-Minisign([string] $TempDirectory, [string] $Architecture) {
+  $installed = Get-Command -Name "minisign.exe", "minisign" -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($installed) { return $installed.Source }
+
+  Write-Host "minisign was not found; downloading the pinned official verifier."
+  $bootstrapArchive = Join-Path $TempDirectory "minisign-bootstrap.zip"
+  Get-ApprovedFile $MinisignBootstrapUrl $bootstrapArchive
+  if ((Get-Item $bootstrapArchive).Length -ne $MinisignBootstrapSize) {
+    throw "Minisign bootstrap archive size mismatch."
+  }
+  $bootstrapHash = (Get-FileHash -Algorithm SHA256 -Path $bootstrapArchive).Hash.ToLowerInvariant()
+  if ($bootstrapHash -cne $MinisignBootstrapSha256) {
+    throw "Minisign bootstrap archive checksum mismatch."
+  }
+
+  $entryName = if ($Architecture -eq "arm64") {
+    "minisign-win64/aarch64/minisign.exe"
+  } else {
+    "minisign-win64/x86_64/minisign.exe"
+  }
+  $bootstrapZip = [System.IO.Compression.ZipFile]::OpenRead($bootstrapArchive)
+  try {
+    $entries = @($bootstrapZip.Entries | Where-Object { $_.FullName -ceq $entryName -and $_.Name -ceq "minisign.exe" })
+    if ($entries.Count -ne 1) { throw "Minisign bootstrap archive is missing the expected executable." }
+    $bootstrapExecutable = Join-Path $TempDirectory "minisign.exe"
+    $input = $entries[0].Open()
+    $output = [System.IO.File]::Create($bootstrapExecutable)
+    try { $input.CopyTo($output) } finally { $output.Dispose(); $input.Dispose() }
+  }
+  finally { $bootstrapZip.Dispose() }
+  if ((Get-Item $bootstrapExecutable).Length -le 0) { throw "Minisign bootstrap executable is empty." }
+  return $bootstrapExecutable
+}
+
 $archMap = @{ "AMD64" = "amd64"; "ARM64" = "arm64" }
-$arch = $archMap[$env:PROCESSOR_ARCHITECTURE]
-if (-not $arch) { throw "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE" }
+# PROCESSOR_ARCHITEW6432 reports the native architecture when a 32-bit or x64
+# PowerShell process is running under Windows-on-Windows emulation.
+$processorArchitecture = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+$processorArchitecture = ([string]$processorArchitecture).ToUpperInvariant()
+$arch = $archMap[$processorArchitecture]
+if (-not $arch) { throw "Unsupported architecture: $processorArchitecture" }
 $target = "windows-$arch"
 
-$minisign = Get-Command minisign -ErrorAction SilentlyContinue
-if (-not $minisign) { throw "minisign is required; signature verification cannot be skipped." }
 if ($MinisignPublicKey -eq "REPLACE_WITH_MINISIGN_PUBLIC_KEY") { throw "Installer public key is not configured." }
 
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("fleet-install-" + [System.Guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $tmp | Out-Null
 try {
+  $minisignPath = Resolve-Minisign $tmp $arch
   $manifestPath = Join-Path $tmp "manifest.json"
   Get-ApprovedFile "$BaseUrl/manifest.json" $manifestPath
   $manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
@@ -109,7 +158,7 @@ try {
   if ((Get-Item $archivePath).Length -ne $artifactSize) { throw "Artifact size mismatch." }
   Get-ApprovedFile $binary.signature_url $sigPath
 
-  & $minisign.Source -Vm $archivePath -P $MinisignPublicKey -x $sigPath | Out-Null
+  & $minisignPath -Vm $archivePath -P $MinisignPublicKey -x $sigPath | Out-Null
   if ($LASTEXITCODE -ne 0) { throw "Minisign verification failed." }
   $signatureLines = Get-Content $sigPath
   if ($signatureLines.Count -lt 3 -or -not $signatureLines[2].StartsWith("trusted comment: ")) { throw "Minisign trusted comment is missing." }
@@ -120,7 +169,6 @@ try {
   $actual = (Get-FileHash -Algorithm SHA256 -Path $archivePath).Hash.ToLowerInvariant()
   if ($actual -cne $binary.sha256.ToLowerInvariant()) { throw "Checksum mismatch." }
 
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
   $zip = [System.IO.Compression.ZipFile]::OpenRead($archivePath)
   try {
     $entries = @($zip.Entries | Where-Object { $_.FullName -ceq "fleet.exe" -and $_.Name -ceq "fleet.exe" })
@@ -139,12 +187,18 @@ try {
   Write-Host "Installed Cenvero Fleet $version to $installDir\fleet.exe"
 
   $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-  if ($currentPath -notlike "*$installDir*") {
-    $choice = Read-Host "Add $installDir to PATH? (Y/N)"
-    if ($choice -match "^[Yy]$") {
-      [Environment]::SetEnvironmentVariable("PATH", (($currentPath, $installDir | Where-Object { $_ }) -join ";"), "User")
-      $env:PATH += ";$installDir"
-    } else { Write-Host "Skipped. Add manually: `$env:PATH += ';$installDir'" }
+  $pathEntries = @($currentPath -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim().TrimEnd("\") })
+  if ($pathEntries -notcontains $installDir.TrimEnd("\")) {
+    if ($env:FLEET_SKIP_PATH_UPDATE -eq "1") {
+      Write-Host "Skipped PATH update. Add manually: `$env:PATH += ';$installDir'"
+    } else {
+      $choice = Read-Host "Add $installDir to PATH? (Y/N)"
+      if ($choice -match "^[Yy]$") {
+        $newPath = @($currentPath, $installDir) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        [Environment]::SetEnvironmentVariable("PATH", ($newPath -join ";"), "User")
+        $env:PATH += ";$installDir"
+      } else { Write-Host "Skipped. Add manually: `$env:PATH += ';$installDir'" }
+    }
   }
   Write-Host "Run: fleet init"
 }

--- a/scripts/test-posix-installer.sh
+++ b/scripts/test-posix-installer.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+set -euo pipefail
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  echo "this smoke test installs into a system binary directory and must run only on a GitHub Actions runner" >&2
+  exit 1
+fi
+
+for dependency in curl jq minisign; do
+  command -v "${dependency}" >/dev/null 2>&1 || {
+    echo "missing smoke-test dependency: ${dependency}" >&2
+    exit 1
+  }
+done
+
+manifest="$(curl -fsSL https://fleet.cenvero.org/manifest.json)"
+expected_version="$(jq -er '.channels.stable.version | select(type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+"))' <<<"${manifest}")"
+expected_number="${expected_version#v}"
+
+os="$(uname -s)"
+case "${os}" in
+  Linux)
+    candidates=(/usr/bin/fleet)
+    ;;
+  Darwin)
+    candidates=(/usr/local/bin/fleet /opt/homebrew/bin/fleet)
+    ;;
+  *)
+    echo "unsupported smoke-test OS: ${os}" >&2
+    exit 1
+    ;;
+esac
+
+# GitHub-hosted runners are ephemeral. Remove any image-provided copy so the
+# assertions below can only succeed with the binary installed by this run.
+for candidate in "${candidates[@]}"; do
+  sudo rm -f "${candidate}"
+done
+
+FLEET_CHANNEL=stable FLEET_VERSION="${expected_version}" sh ./public/install.sh
+
+installed=""
+for candidate in "${candidates[@]}"; do
+  if [[ -x "${candidate}" ]]; then
+    installed="${candidate}"
+    break
+  fi
+done
+if [[ -z "${installed}" ]]; then
+  echo "installer did not create fleet in an expected system binary directory" >&2
+  exit 1
+fi
+
+version_output="$("${installed}" --version)"
+if [[ "${version_output}" != *"${expected_number}"* ]]; then
+  echo "installed version mismatch: expected ${expected_version}, got: ${version_output}" >&2
+  exit 1
+fi
+
+help_output="$("${installed}" --help)"
+if [[ "${help_output}" != *"Cenvero Fleet"* ]]; then
+  echo "installed fleet failed its command smoke test" >&2
+  exit 1
+fi
+
+printf 'Installed and executed %s at %s on %s/%s\n' "${version_output}" "${installed}" "${os}" "$(uname -m)"

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -80,6 +80,12 @@ grep -q 'verification cannot be skipped' "${TMP_DIR}/public/install.sh"
 grep -q 'EXPECTED_COMMENT="cenvero-fleet fleet' "${TMP_DIR}/public/install.sh"
 grep -q 'Release signature URL is required' "${TMP_DIR}/public/install.ps1"
 grep -q 'Signature is not bound' "${TMP_DIR}/public/install.ps1"
+grep -Fq 'Add-Type -AssemblyName System.Net.Http' "${TMP_DIR}/public/install.ps1"
+grep -Fq 'minisign-0.12-win64.zip' "${TMP_DIR}/public/install.ps1"
+grep -Fq '37b600344e20c19314b2e82813db2bfdcc408b77b876f7727889dbd46d539479' "${TMP_DIR}/public/install.ps1"
+if grep -Fq 'minisign is required' "${TMP_DIR}/public/install.ps1"; then
+  echo "Windows installer still requires a preinstalled minisign executable" >&2; exit 1
+fi
 grep -q -- '--max-redirs 0' "${TMP_DIR}/public/install" "${TMP_DIR}/public/install.sh"
 grep -Fq "AllowAutoRedirect = \$false" "${TMP_DIR}/public/install.ps1"
 grep -q 'GetHostAddresses' "${TMP_DIR}/public/install.ps1"

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+param(
+  [Parameter(Mandatory = $true)]
+  [int] $ExpectedMajor
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+if ($PSVersionTable.PSVersion.Major -ne $ExpectedMajor) {
+  throw "expected PowerShell $ExpectedMajor, got $($PSVersionTable.PSVersion)"
+}
+
+# Resolve the currently published stable version first and pin this test
+# invocation to it, avoiding a race if the channel advances mid-run.
+$manifest = Invoke-RestMethod -Uri "https://fleet.cenvero.org/manifest.json"
+$expectedVersion = [string]$manifest.channels.stable.version
+if ($expectedVersion -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+') {
+  throw "stable manifest returned an invalid version: $expectedVersion"
+}
+
+$installPath = Join-Path $HOME ".local\bin\fleet.exe"
+Remove-Item -LiteralPath $installPath -Force -ErrorAction SilentlyContinue
+
+# Exclude package-manager directories so the installer must use its pinned
+# minisign bootstrap, matching a clean Windows host.
+$env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+if (Get-Command minisign -ErrorAction SilentlyContinue) {
+  throw "test setup unexpectedly found minisign"
+}
+$env:FLEET_CHANNEL = "stable"
+$env:FLEET_VERSION = $expectedVersion
+$env:FLEET_SKIP_PATH_UPDATE = "1"
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+& (Join-Path $repositoryRoot "public\install.ps1")
+
+if (-not (Test-Path -LiteralPath $installPath -PathType Leaf)) {
+  throw "installer did not create fleet.exe"
+}
+
+$versionOutput = (& $installPath --version 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) {
+  throw "installed fleet.exe --version failed with exit code $LASTEXITCODE"
+}
+$expectedNumber = $expectedVersion.TrimStart('v')
+if ($versionOutput -notmatch [Regex]::Escape($expectedNumber)) {
+  throw "installed version mismatch: expected $expectedVersion, got: $versionOutput"
+}
+
+$helpOutput = (& $installPath --help 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or $helpOutput -notmatch 'Cenvero Fleet') {
+  throw "installed fleet.exe failed its command smoke test"
+}
+
+# The bootstrap verifier must remain temporary; it must not be installed or
+# added to PATH after Fleet verification completes.
+if (Get-Command minisign -ErrorAction SilentlyContinue) {
+  throw "temporary minisign verifier leaked into PATH"
+}
+
+Write-Host "Installed and executed $versionOutput with PowerShell $($PSVersionTable.PSVersion)"


### PR DESCRIPTION
## Summary

- Explain what changed
- Explain the operator or maintainer impact

## Scope

- What is intentionally included
- What is intentionally not included

## Verification

- [ ] `make fmt`
- [ ] `make test`
- [ ] `make build`
- [ ] `make scale` if transport, metrics, TUI, or performance-sensitive behavior changed
- [ ] `make release-ready` if release tooling, updates, signing, or docs for release flow changed

List any additional focused commands you ran:

```text
```

## Documentation

- [ ] Docs were updated if behavior, config, or release flow changed
- [ ] No docs update was needed

If no docs update was needed, explain why:

## Release and Security Impact

- [ ] No release flow impact
- [ ] No security-sensitive impact
- [ ] This change affects transport, crypto, update, bootstrap, or signing behavior

Notes:

## DCO

- [ ] Commits are signed off with `git commit -s`
