### PR TITLE
fix(onboarding): restore SSH-first agent downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,51 @@ Omit sections that have no entries for that release.
   pending activation and preserves the observed live version until restart and
   reconnect.
 
+## [v2.4.3] — 2026-09-11 (stable)
+
+Restores SSH-first Linux agent onboarding while retaining fail-closed release
+verification, and fixes onboarding state, port, version-display, and updater
+resilience regressions introduced in the v2.4 line.
+
+### Changed
+
+- Linux auto-install now opens the authenticated, host-key-pinned SSH connection
+  first, detects the target with `uname`, and makes that server download only its
+  matching agent manifest, archive, and signature. It prefers a BusyBox-compatible
+  three-attempt `wget` loop and falls back to bounded, retrying `curl`; the
+  controller no longer downloads GitHub agent archives during auto-install.
+- The target-fetched payload is streamed through the same SSH connection for
+  controller-side verification before the single extracted agent binary is
+  staged and installed.
+
+### Fixed
+
+- Transient updater and manifest HTTP failures now use bounded, cancellation-aware
+  retries without leaking signed URL query parameters in diagnostics.
+- Server onboarding rejects duplicate names before collecting credentials,
+  confirms before persistence, preserves configured login and agent ports, and
+  records explicit `installing`, `failed`, `managed`, and `reconcile-required`
+  states with non-secret retry metadata.
+- Post-install state or audit failures are no longer mislabeled as remote install
+  failures, and manual bootstrap retries reuse the stored non-secret connection
+  settings.
+- Agent versions and server lifecycle statuses are rendered consistently across
+  list, inventory, dashboard, update, and notification output.
+- SSH bootstrap cancellation now covers channel-open, exec-request, and command
+  wait stalls; failed uploads are cleaned locally or over a freshly pinned SSH
+  connection without masking the original error.
+
+### Security
+
+- Agent release selection remains bound to the exact product, semantic version,
+  Linux target, archive URL, and signature URL, with embedded-key minisign
+  verification, an exact trusted comment, declared and actual size checks,
+  SHA-256 verification, and bounded extraction of the regular `fleet-agent`
+  member.
+- Target acquisition now has one whole-operation deadline, target-side file-size
+  limits, bounded controller capture, interruption cleanup, and exact-size atomic
+  `.part` uploads so truncated staging files are never installed.
+
 ## [v2.3.0] — 2026-06-21 (stable)
 
 Shell-completion overhaul, two new operator-configurable lifecycle settings

--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ fleet server add web-01 192.0.2.10 \
 ```
 
 The auto-install:
-- Detects the server arch via `uname -m`
-- Downloads the correct `fleet-agent` release binary
+- Detects the server arch via `uname -m` over the host-key-pinned SSH connection
+- Downloads only the matching `fleet-agent` archive, signature, and manifest **from the target server** using `wget` with `curl` fallback and bounded retries
+- Streams the downloaded payloads through SSH so the controller can fail-closed verify the exact release URL/target, minisign signature, trusted comment, size, and SHA-256 before installation; the controller does not fetch agent archives from GitHub itself
 - Installs it to `/opt/cenvero-fleet/fleet-agent`
 - Creates, enables, and starts `cenvero-fleet-agent.service` via systemd
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -20,7 +20,7 @@ For Linux-first remote bootstrap with automatic agent installation:
 fleet server add web-01 192.0.2.10 --mode direct --login-user root --login-key ~/.ssh/id_ed25519
 ```
 
-This SSHes into the server, downloads the correct `fleet-agent` binary, installs it under `/opt/cenvero-fleet/`, and starts it as a systemd service.
+This SSHes into the server, detects its architecture, and makes the target download only the matching `fleet-agent` archive, signature, and release manifest (`wget` first, with `curl` fallback and retries). The payloads are streamed through the pinned SSH connection so the controller verifies minisign, trusted version/target binding, size, and SHA-256 before it installs the extracted binary under `/opt/cenvero-fleet/` and starts it as a systemd service. The controller machine does not download agent archives from GitHub during auto-install.
 
 **Changed bootstrap host key.** The bootstrap SSH host key is pinned on first install. If a
 later install finds a *different* key (the box was reinstalled or re-keyed — or, rarely, a

--- a/internal/cli/agentupdate.go
+++ b/internal/cli/agentupdate.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cenvero/fleet/internal/core"
+	"github.com/cenvero/fleet/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -165,16 +166,17 @@ func updateBatch(cmd *cobra.Command, app *core.App, servers []string) error {
 			continue
 		}
 		a := res.Agents[0]
+		displayVersion := version.DisplaySemVer(a.AgentVersion)
 		switch {
 		case a.Error != "":
 			fmt.Fprintf(out, "  %-24s ERROR  %s\n", name, a.Error)
 			failed = append(failed, name)
 		case a.AlreadySynced:
-			fmt.Fprintf(out, "  %-24s up-to-date (%s)\n", name, a.AgentVersion)
+			fmt.Fprintf(out, "  %-24s up-to-date (%s)\n", name, displayVersion)
 		case a.Updated:
-			fmt.Fprintf(out, "  %-24s updated -> %s\n", name, a.AgentVersion)
+			fmt.Fprintf(out, "  %-24s updated -> %s\n", name, displayVersion)
 		default:
-			fmt.Fprintf(out, "  %-24s processed (%s)\n", name, a.AgentVersion)
+			fmt.Fprintf(out, "  %-24s processed (%s)\n", name, displayVersion)
 		}
 	}
 	if len(failed) > 0 {

--- a/internal/cli/agentversion.go
+++ b/internal/cli/agentversion.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/cenvero/fleet/internal/version"
@@ -15,10 +14,9 @@ import (
 
 // newAgentVersionCommand builds `fleet agent version [--all|<server>]`.
 //
-// It reports the observed agent version per server, NORMALIZED (a leading 'v'
-// stripped and surrounding spaces trimmed) so "v2.1.0" and "2.1.0" compare
-// equal. Versions are flagged when they differ from the reference version: the
-// controller's own version, or — when the controller is a dev build — the most
+// It reports the observed agent version per server in one canonical v-prefixed
+// form so "v2.1.0" and "2.1.0" compare and display identically. Versions are
+// flagged when they differ from the reference version: the controller's own version, or — when the controller is a dev build — the most
 // common normalized agent version across the fleet.
 //
 // NOTE: no top-level `fleet agent` command exists yet. This returns a standalone
@@ -31,8 +29,9 @@ func newAgentVersionCommand(configDir *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version [--all|<server>]",
 		Short: "Report agent versions per server and flag mismatches",
-		Long: "Report the observed agent version for each server, normalized so a leading 'v'\n" +
-			"and surrounding whitespace are ignored (so 'v2.1.0' and '2.1.0' are equal).\n\n" +
+		Long: "Report the observed agent version for each server in one canonical v-prefixed form\n" +
+			"(so 'v2.1.0' and '2.1.0' display and compare identically). Missing, sentinel,\n" +
+			"or malformed values are shown as unavailable and never become references.\n\n" +
 			"Versions are compared against a reference (the controller version, or the most\n" +
 			"common agent version when the controller is a dev build) and mismatches are\n" +
 			"flagged.\n\n" +
@@ -114,7 +113,12 @@ func runAgentVersion(cmd *cobra.Command, configDir, only string) error {
 			status = "unknown"
 		case reference != "" && r.Normalized != reference:
 			status = "MISMATCH"
+			if !r.Reachable {
+				status = "offline, MISMATCH"
+			}
 			mismatches++
+		case !r.Reachable:
+			status = "offline (cached)"
 		}
 		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", r.Server, display, status); err != nil {
 			return err
@@ -129,17 +133,14 @@ func runAgentVersion(cmd *cobra.Command, configDir, only string) error {
 	return nil
 }
 
-// normalizeAgentVersion trims surrounding whitespace and a single leading 'v'
-// (or 'V') so "v2.1.0", " 2.1.0 ", and "2.1.0" all normalize to "2.1.0".
-func normalizeAgentVersion(v string) string {
-	v = strings.TrimSpace(v)
-	if v == "" {
+// normalizeAgentVersion returns the shared, strict, v-prefixed semver form.
+// Sentinels and malformed values are unavailable and never become references.
+func normalizeAgentVersion(raw string) string {
+	normalized, ok := version.NormalizeSemVer(raw)
+	if !ok {
 		return ""
 	}
-	if v[0] == 'v' || v[0] == 'V' {
-		v = strings.TrimSpace(v[1:])
-	}
-	return v
+	return normalized
 }
 
 // referenceVersion picks the version to compare against: the controller's own

--- a/internal/cli/inventory.go
+++ b/internal/cli/inventory.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/cenvero/fleet/internal/core"
+	"github.com/cenvero/fleet/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -186,7 +187,7 @@ func writeInventoryTable(cmd *cobra.Command, inv core.Inventory) error {
 			disk,
 			dash(strings.Join(it.PublicIPs, ",")),
 			dash(joinPorts(it.ListenPorts)),
-			dash(it.AgentVersion),
+			version.DisplaySemVer(it.AgentVersion),
 			dash(formatTags(it.Tags)),
 		); err != nil {
 			return err

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -954,7 +954,7 @@ func newServerCommand(configDir *string) *cobra.Command {
 		Short: "Add a server to the fleet",
 		Args:  cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			scanner := bufio.NewScanner(os.Stdin)
+			scanner := bufio.NewScanner(cmd.InOrStdin())
 
 			prompt := func(label, def string) string {
 				if def != "" {
@@ -984,21 +984,37 @@ func newServerCommand(configDir *string) *cobra.Command {
 			if interactive {
 				fmt.Fprintln(cmd.OutOrStdout(), "Adding a server — press Enter to accept defaults.")
 				fmt.Fprintln(cmd.OutOrStdout())
+			}
+			if name == "" {
+				name = prompt("Server name", "")
 				if name == "" {
-					name = prompt("Server name", "")
-					if name == "" {
-						return fmt.Errorf("server name is required")
-					}
+					return fmt.Errorf("server name is required")
 				}
+			}
+
+			app, err := openApp(*configDir)
+			if err != nil {
+				return err
+			}
+			defer app.Close()
+			existingServers, err := app.ListServers()
+			if err != nil {
+				return err
+			}
+			for _, existing := range existingServers {
+				if existing.Name == name {
+					return fmt.Errorf("server %q already exists at %s:%d; retry its agent setup with 'fleet server bootstrap %s', or remove it with 'fleet server remove %s --force' before adding it again", name, existing.Address, existing.Port, name, name)
+				}
+			}
+
+			if address == "" {
+				address = prompt("IP address or hostname", "")
 				if address == "" {
-					address = prompt("IP address or hostname", "")
-					if address == "" {
-						return fmt.Errorf("address is required")
-					}
+					return fmt.Errorf("address is required")
 				}
-				if !cmd.Flags().Changed("mode") {
-					mode = prompt("Transport mode (direct/reverse)", "direct")
-				}
+			}
+			if interactive && !cmd.Flags().Changed("mode") {
+				mode = prompt("Transport mode (direct/reverse)", "direct")
 			}
 
 			parsedMode, err := transport.ParseMode(mode)
@@ -1009,19 +1025,8 @@ func newServerCommand(configDir *string) *cobra.Command {
 			// For direct mode: prompt for login credentials interactively
 			// unless --no-agent was passed or credentials were given as flags.
 			if parsedMode == transport.ModeDirect && !noAgent {
-				if loginUser == "" {
-					if interactive {
-						loginUser = prompt("Login user for agent install (leave blank to skip)", "root")
-					} else {
-						// non-interactive: ask on stdin since --login-user was not given
-						fmt.Fprintf(cmd.OutOrStdout(), "Login user for agent install [root] (--no-agent to skip): ")
-						scanner.Scan()
-						v := strings.TrimSpace(scanner.Text())
-						if v == "" {
-							v = "root"
-						}
-						loginUser = v
-					}
+				if loginUser == "" && interactive {
+					loginUser = prompt("Login user for agent install (--no-agent to skip)", "root")
 				}
 				if loginUser != "" && loginKey == "" && loginPassword == "" {
 					if interactive {
@@ -1046,24 +1051,25 @@ func newServerCommand(configDir *string) *cobra.Command {
 						}
 					}
 				}
-				if loginUser != "" && loginPort == 22 && interactive {
+				if loginUser != "" && loginPort == 22 && interactive && !cmd.Flags().Changed("login-port") {
 					lps := prompt("Login SSH port", "22")
 					lpi, err := strconv.Atoi(lps)
-					if err == nil {
-						loginPort = lpi
+					if err != nil {
+						return fmt.Errorf("invalid login port %q: must be 1-65535", lps)
 					}
+					loginPort = lpi
 				}
 				if loginUser != "" && !cmd.Flags().Changed("sudo") && interactive {
 					s := prompt("Use sudo? (yes/no)", "no")
 					useSudo = strings.HasPrefix(strings.ToLower(s), "y")
 				}
 			}
-
-			app, err := openApp(*configDir)
-			if err != nil {
-				return err
+			if port < 1 || port > 65535 {
+				return fmt.Errorf("invalid agent port %d: must be 1-65535", port)
 			}
-			defer app.Close()
+			if loginUser != "" && (loginPort < 1 || loginPort > 65535) {
+				return fmt.Errorf("invalid login port %d: must be 1-65535", loginPort)
+			}
 
 			// Reverse-mode servers get a one-time enrollment token the agent must
 			// present on first connect before its key is pinned (closes the
@@ -1073,6 +1079,29 @@ func newServerCommand(configDir *string) *cobra.Command {
 				enrollSecret, err = core.GenerateEnrollSecret()
 				if err != nil {
 					return err
+				}
+			}
+
+			autoInstall := loginUser != "" && parsedMode == transport.ModeDirect && !noAgent
+			lp := loginPort
+			if lp == 0 {
+				lp = 22
+			}
+			if autoInstall {
+				fmt.Fprintln(cmd.OutOrStdout())
+				fmt.Fprintf(cmd.OutOrStdout(), "The following will be installed on %s (%s:%d):\n", name, address, lp)
+				fmt.Fprintln(cmd.OutOrStdout(), "  • fleet-agent binary  →  /opt/cenvero-fleet/fleet-agent")
+				fmt.Fprintf(cmd.OutOrStdout(), "  • agent endpoint  →  %s:%d\n", address, port)
+				fmt.Fprintln(cmd.OutOrStdout(), "  • cenvero-fleet-agent.service  →  systemd unit (enabled on boot)")
+				fmt.Fprintln(cmd.OutOrStdout(), "  • authorized_keys entry for this controller's public key")
+				fmt.Fprintln(cmd.OutOrStdout())
+				fmt.Fprintln(cmd.OutOrStdout(), "To skip, press Ctrl+C now or re-run with --no-agent.")
+				fmt.Fprintf(cmd.OutOrStdout(), "Press Enter to continue: ")
+				if !scanner.Scan() {
+					if err := scanner.Err(); err != nil {
+						return fmt.Errorf("read install confirmation: %w", err)
+					}
+					return fmt.Errorf("agent install confirmation canceled; server was not added")
 				}
 			}
 
@@ -1088,32 +1117,31 @@ func newServerCommand(configDir *string) *cobra.Command {
 				return err
 			}
 
-			if loginUser != "" && parsedMode == transport.ModeDirect && !noAgent {
-				lp := loginPort
-				if lp == 0 {
-					lp = 22
-				}
-				fmt.Fprintln(cmd.OutOrStdout())
-				fmt.Fprintf(cmd.OutOrStdout(), "The following will be installed on %s (%s:%d):\n", name, address, lp)
-				fmt.Fprintln(cmd.OutOrStdout(), "  • fleet-agent binary  →  /opt/cenvero-fleet/fleet-agent")
-				fmt.Fprintln(cmd.OutOrStdout(), "  • cenvero-fleet-agent.service  →  systemd unit (enabled on boot)")
-				fmt.Fprintln(cmd.OutOrStdout(), "  • authorized_keys entry for this controller's public key")
-				fmt.Fprintln(cmd.OutOrStdout())
-				fmt.Fprintln(cmd.OutOrStdout(), "To skip, press Ctrl+C now or re-run with --no-agent.")
-				fmt.Fprintf(cmd.OutOrStdout(), "Press Enter to continue: ")
-				scanner.Scan()
-
+			if autoInstall {
 				fmt.Fprintf(cmd.OutOrStdout(), "\nInstalling agent on %s...\n", name)
 				// If the box was reinstalled/re-keyed since it was last pinned, a
 				// changed bootstrap host key would otherwise hard-fail. With
 				// --accept-new-host-key we re-pin automatically; on a terminal we ask.
 				app.HostKeyChangedPrompt = resolveHostKeyPrompt(cmd, acceptNewHostKey)
-				if err := app.AutoInstallAgent(name, loginUser, loginKey, loginPassword, lp, useSudo); err != nil {
-					return fmt.Errorf("agent install failed (server was added): %w\n"+
-						"Run 'fleet server bootstrap %s --login-user %s --accept-new-host-key' to retry manually", err, name, loginUser)
+				installCtx, stopInstall := signal.NotifyContext(cmd.Context(), os.Interrupt)
+				defer stopInstall()
+				installErr := app.AutoInstallAgentContext(installCtx, name, loginUser, loginKey, loginPassword, lp, useSudo)
+				if installErr != nil {
+					var completionErr *core.AgentInstallCompletionError
+					if errors.As(installErr, &completionErr) {
+						if completionErr.ManagedStateSaved {
+							return fmt.Errorf("agent installed and running on %s and controller state is managed, but the audit event could not be written: %w", name, completionErr.Err)
+						}
+						return fmt.Errorf("agent installed remotely on %s, but controller state needs reconciliation: %w\n"+
+							"Do not reinstall blindly; inspect 'fleet server show %s' and try 'fleet server reconnect %s'",
+							name, completionErr.Err, name, name)
+					}
+					return fmt.Errorf("agent install failed; server %q remains registered at %s:%d with install status failed: %w\n"+
+						"Retry with 'fleet server bootstrap %s --login-user %s --login-port %d --listen 0.0.0.0:%d --sudo=%t --accept-new-host-key', or remove it with 'fleet server remove %s --force' and add it again",
+						name, address, port, installErr, name, loginUser, lp, port, useSudo, name)
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "Agent installed and running. Connect with: fleet server reconnect %s\n", name)
-			} else if parsedMode == transport.ModeDirect && (noAgent || loginUser == "") {
+			} else if parsedMode == transport.ModeDirect {
 				record, _ := app.GetServer(name)
 				fmt.Fprintln(cmd.OutOrStdout(), core.AgentInstallInstructions(record, parsedMode))
 			}
@@ -1383,7 +1411,7 @@ If the server is unreachable or credentials have changed, use one of:
 		},
 	}
 	bootstrapCmd.Flags().StringVar(&bootstrapLoginUser, "login-user", "", "SSH login user used to bootstrap the remote host")
-	bootstrapCmd.Flags().IntVar(&bootstrapLoginPort, "login-port", 22, "SSH port used for the bootstrap login")
+	bootstrapCmd.Flags().IntVar(&bootstrapLoginPort, "login-port", 0, "SSH port used for bootstrap login (default: stored port or 22)")
 	bootstrapCmd.Flags().StringVar(&bootstrapLoginKey, "login-key", "", "SSH private key used for the bootstrap login")
 	bootstrapCmd.Flags().StringVar(&bootstrapAgentBinary, "agent-binary", "", "local fleet-agent binary to upload")
 	bootstrapCmd.Flags().StringVar(&bootstrapListenAddr, "listen", "", "agent listen address for direct mode")
@@ -2100,7 +2128,7 @@ func describeStaleAgents(stale []core.AgentVersionMismatch) string {
 	case 0:
 		return ""
 	case 1:
-		return fmt.Sprintf("1 managed agent is on a different version: %s (%s).", stale[0].Server, stale[0].AgentVersion)
+		return fmt.Sprintf("1 managed agent is on a different version: %s (%s).", stale[0].Server, version.DisplaySemVer(stale[0].AgentVersion))
 	default:
 		names := make([]string, 0, len(stale))
 		for _, s := range stale {
@@ -2507,9 +2535,16 @@ func writeServerTable(cmd *cobra.Command, servers []core.ServerRecord) error {
 		return err
 	}
 	for _, server := range servers {
-		status := "offline"
-		if server.Observed.Reachable {
+		status := "pending"
+		switch {
+		case server.Observed.Reachable:
 			status = "online"
+		case server.Agent.Status == "failed":
+			status = "install-failed"
+		case server.Agent.Status == "reconcile-required":
+			status = "reconcile-required"
+		case !server.Observed.LastSeen.IsZero() || server.Observed.LastError != "":
+			status = "offline"
 		}
 		osArch := strings.Trim(strings.Join([]string{server.Observed.OS, server.Observed.Arch}, "/"), "/")
 		if osArch == "" {
@@ -2519,11 +2554,8 @@ func writeServerTable(cmd *cobra.Command, servers []core.ServerRecord) error {
 		if node == "" {
 			node = "-"
 		}
-		version := server.Observed.AgentVersion
-		if version == "" {
-			version = "-"
-		}
-		if _, err := fmt.Fprintf(w, "%s\t%s\t%s:%d\t%s\t%s\t%s\t%s\n", server.Name, server.Mode, server.Address, server.Port, status, node, osArch, version); err != nil {
+		agentVersion := version.DisplaySemVer(server.Observed.AgentVersion)
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s:%d\t%s\t%s\t%s\t%s\n", server.Name, server.Mode, server.Address, server.Port, status, node, osArch, agentVersion); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/server_onboarding_test.go
+++ b/internal/cli/server_onboarding_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cenvero/fleet/internal/core"
+	"github.com/cenvero/fleet/internal/transport"
+	"github.com/cenvero/fleet/internal/update"
+	"github.com/spf13/cobra"
+)
+
+func newServerCommandTestConfig(t *testing.T) string {
+	t.Helper()
+	configDir := t.TempDir()
+	if _, err := core.Initialize(core.InitOptions{
+		ConfigDir: configDir, Alias: "fleet", DefaultMode: transport.ModeDirect,
+		CryptoAlgorithm: "ed25519", UpdateChannel: "stable", UpdatePolicy: update.PolicyNotifyOnly,
+	}); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	return configDir
+}
+
+func TestServerAddRejectsDuplicateBeforeAddressPrompt(t *testing.T) {
+	configDir := newServerCommandTestConfig(t)
+	app, err := core.Open(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddServer(core.ServerRecord{Name: "herm", Address: "91.99.197.39", Port: 5911, Mode: transport.ModeDirect}); err != nil {
+		t.Fatal(err)
+	}
+	_ = app.Close()
+
+	cmd := newServerCommand(&configDir)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs([]string{"add", "herm"})
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "already exists at 91.99.197.39:5911") {
+		t.Fatalf("error=%v, want actionable duplicate rejection", err)
+	}
+	if strings.Contains(out.String(), "IP address or hostname") {
+		t.Fatalf("duplicate add prompted for address before rejection: %q", out.String())
+	}
+	if !strings.Contains(err.Error(), "server bootstrap herm") || !strings.Contains(err.Error(), "server remove herm --force") {
+		t.Fatalf("duplicate error lacks retry/remove guidance: %v", err)
+	}
+}
+
+func TestServerAddConfirmationEOFDoesNotPersist(t *testing.T) {
+	configDir := newServerCommandTestConfig(t)
+	cmd := newServerCommand(&configDir)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs([]string{"add", "new-node", "192.0.2.20", "--login-user", "root", "--login-key", "/tmp/test-key"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "server was not added") {
+		t.Fatalf("error=%v, want fail-closed confirmation", err)
+	}
+
+	app, openErr := core.Open(configDir)
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	defer app.Close()
+	servers, listErr := app.ListServers()
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(servers) != 0 {
+		t.Fatalf("confirmation failure persisted servers: %+v", servers)
+	}
+}
+
+func TestServerAddPreservesConfiguredAgentPort(t *testing.T) {
+	configDir := newServerCommandTestConfig(t)
+	cmd := newServerCommand(&configDir)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"add", "custom-port", "192.0.2.30", "--no-agent", "--port", "5911"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("server add error = %v", err)
+	}
+	if !strings.Contains(out.String(), "fleet-agent serve --listen 0.0.0.0:5911") || !strings.Contains(out.String(), "ensure port 5911 is reachable") {
+		t.Fatalf("manual instructions did not use configured port:\n%s", out.String())
+	}
+	app, err := core.Open(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	record, err := app.GetServer("custom-port")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Port != 5911 {
+		t.Fatalf("stored port=%d, want 5911", record.Port)
+	}
+}
+
+func TestWriteServerTableNormalizesVersionAndInstallState(t *testing.T) {
+	servers := []core.ServerRecord{
+		{Name: "online", Address: "192.0.2.1", Port: 2222, Mode: transport.ModeDirect, Observed: core.ServerObservation{Reachable: true, AgentVersion: "2.4.0"}},
+		{Name: "failed", Address: "192.0.2.2", Port: 5911, Mode: transport.ModeDirect, Agent: core.AgentInstall{Status: "failed"}, Observed: core.ServerObservation{AgentVersion: "version unavailable"}},
+		{Name: "new", Address: "192.0.2.3", Port: 3022, Mode: transport.ModeDirect},
+	}
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	if err := writeServerTable(cmd, servers); err != nil {
+		t.Fatal(err)
+	}
+	text := out.String()
+	for _, want := range []string{"online", "v2.4.0", "install-failed", "192.0.2.2:5911", "pending"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("table missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "version unavailable") {
+		t.Fatalf("table rendered invalid sentinel as a version:\n%s", text)
+	}
+}
+
+func TestNormalizeAgentVersionRejectsSentinels(t *testing.T) {
+	if got := normalizeAgentVersion("2.4.2"); got != "v2.4.2" {
+		t.Fatalf("bare version normalized to %q", got)
+	}
+	if got := normalizeAgentVersion("v2.4.2"); got != "v2.4.2" {
+		t.Fatalf("prefixed version normalized to %q", got)
+	}
+	if got := normalizeAgentVersion("version unavailable"); got != "" {
+		t.Fatalf("sentinel normalized to %q", got)
+	}
+}
+
+func TestOtherVersionSurfacesUseCanonicalDisplay(t *testing.T) {
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	if err := writeInventoryTable(cmd, core.Inventory{Items: []core.InventoryItem{{
+		Server: "node", Reachable: true, AgentVersion: "2.4.0",
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "v2.4.0") {
+		t.Fatalf("inventory did not canonicalize agent version:\n%s", out.String())
+	}
+	if got := describeStaleAgents([]core.AgentVersionMismatch{{Server: "node", AgentVersion: "2.4.0"}}); !strings.Contains(got, "v2.4.0") {
+		t.Fatalf("stale-agent notice did not canonicalize version: %s", got)
+	}
+}

--- a/internal/core/agent_install.go
+++ b/internal/core/agent_install.go
@@ -11,11 +11,13 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,21 +30,103 @@ import (
 
 const agentGitHubRepo = "cenvero/fleet"
 
+// AgentInstallCompletionError reports that the remote agent installation
+// completed but a controller-side finalization step failed. ManagedStateSaved
+// distinguishes an audit-only failure from a record that needs reconciliation.
+type AgentInstallCompletionError struct {
+	ManagedStateSaved bool
+	Err               error
+}
+
+func (e *AgentInstallCompletionError) Error() string {
+	if e == nil {
+		return "agent install completion error"
+	}
+	if e.ManagedStateSaved {
+		return fmt.Sprintf("agent installed and managed, but audit logging failed: %v", e.Err)
+	}
+	return fmt.Sprintf("agent installed remotely, but controller state needs reconciliation: %v", e.Err)
+}
+
+func (e *AgentInstallCompletionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 // AutoInstallAgent downloads and installs fleet-agent on a remote Linux server via SSH,
 // creates a systemd service, and marks the agent as managed in the server record.
 // If version.Version is "dev", it falls back to uploading a local binary.
 func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPassword string, loginPort int, useSudo bool) error {
+	return a.AutoInstallAgentContext(context.Background(), serverName, loginUser, loginKeyPath, loginPassword, loginPort, useSudo)
+}
+
+// AutoInstallAgentContext is AutoInstallAgent with caller cancellation propagated
+// through release downloads and the SSH bootstrap operation.
+func (a *App) AutoInstallAgentContext(ctx context.Context, serverName, loginUser, loginKeyPath, loginPassword string, loginPort int, useSudo bool) (resultErr error) {
 	server, err := a.GetServer(serverName)
 	if err != nil {
 		return err
 	}
 
+	loginUser = strings.TrimSpace(loginUser)
+	if loginUser == "" {
+		return fmt.Errorf("agent install login user is required")
+	}
 	if loginPort == 0 {
 		loginPort = 22
+	}
+	if loginPort < 1 || loginPort > 65535 {
+		return fmt.Errorf("invalid login port %d: must be 1-65535", loginPort)
 	}
 	if loginKeyPath == "" {
 		loginKeyPath = filepath.Join(a.ConfigDir, "keys", a.Config.Crypto.PrimaryKey)
 	}
+
+	serviceName := defaultServiceName
+	agentPort := server.Port
+	if agentPort == 0 {
+		agentPort = a.Config.Runtime.DefaultAgentPort
+		if agentPort == 0 {
+			agentPort = 2222
+		}
+	}
+	if agentPort < 1 || agentPort > 65535 {
+		return fmt.Errorf("invalid agent port %d: must be 1-65535", agentPort)
+	}
+
+	// Store only non-secret retry metadata before network activity. Passwords are
+	// deliberately never persisted.
+	server.Port = agentPort
+	server.Agent = AgentInstall{
+		Managed:     false,
+		Status:      "installing",
+		BinaryPath:  defaultAgentBinaryPath,
+		ServiceName: serviceName,
+		LoginUser:   loginUser,
+		LoginPort:   loginPort,
+		LoginKey:    loginKeyPath,
+		UseSudo:     useSudo,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	if err := a.SaveServer(server); err != nil {
+		return fmt.Errorf("store agent install intent: %w", err)
+	}
+	installComplete := false
+	defer func() {
+		if resultErr == nil || installComplete {
+			return
+		}
+		status := "failed"
+		var completionErr *AgentInstallCompletionError
+		if errors.As(resultErr, &completionErr) && !completionErr.ManagedStateSaved {
+			status = "reconcile-required"
+		}
+		if stateErr := a.recordAgentInstallProblem(serverName, status, resultErr); stateErr != nil {
+			resultErr = fmt.Errorf("%w (also failed to store install state: %v)", resultErr, stateErr)
+		}
+	}()
 
 	sudo := ""
 	if useSudo {
@@ -52,12 +136,6 @@ func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPasswor
 	pubKeyData, err := os.ReadFile(filepath.Join(a.ConfigDir, "keys", a.Config.Crypto.PrimaryKey+".pub"))
 	if err != nil {
 		return fmt.Errorf("read controller public key: %w", err)
-	}
-
-	serviceName := defaultServiceName
-	agentPort := 2222
-	if a.Config.Runtime.DefaultAgentPort > 0 {
-		agentPort = a.Config.Runtime.DefaultAgentPort
 	}
 
 	serviceUnit, err := buildAgentServiceUnit(server, resolvedBootstrapConfig{
@@ -83,6 +161,7 @@ func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPasswor
 	}
 
 	var installScript string
+	var agentRelease *BootstrapAgentRelease
 	if version.Version == "dev" {
 		// Development build: upload local binary
 		agentBinaryPath, err := resolveAgentBinaryPath("")
@@ -101,22 +180,17 @@ func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPasswor
 		})
 		installScript = buildLocalBinaryInstallScript(server, sudo, serviceName, tempBinPath, tempServicePath, tempKeysPath, tempScriptPath)
 	} else {
-		// Release builds never ask the remote host to trust and execute an unchecked
-		// network download. The controller downloads the complete supported Linux
-		// matrix, verifies each archive against the embedded minisign key, mandatory
-		// SHA-256, exact version/target URL, size, and trusted comment, then uploads
-		// only the extracted binaries over the already host-key-pinned SSH channel.
-		binaries, err := downloadVerifiedAgentBinaries(context.Background(), version.Version, nil)
-		if err != nil {
-			return fmt.Errorf("verify agent release artifacts: %w", err)
+		// Release builds connect to the target first. Over that authenticated,
+		// host-key-pinned SSH connection the target detects its architecture and
+		// downloads only its matching manifest/archive/signature with wget or curl.
+		// The controller then verifies size, minisign binding, SHA-256, and archive
+		// contents before staging the extracted binary back on that same connection.
+		tempBinPath := "/tmp/cenvero-" + token + ".bin"
+		agentRelease = &BootstrapAgentRelease{
+			Version:         version.Version,
+			DestinationPath: tempBinPath,
 		}
-		tempBins := make(map[string]string, len(binaries))
-		for _, target := range agentLinuxTargets {
-			tempPath := "/tmp/cenvero-" + token + "-" + target.arch + ".bin"
-			tempBins[target.name] = tempPath
-			uploads = append(uploads, BootstrapUpload{Path: tempPath, Mode: 0o700, Content: binaries[target.name]})
-		}
-		installScript = buildVerifiedBinaryInstallScript(server, sudo, serviceName, tempBins, tempServicePath, tempKeysPath, tempScriptPath)
+		installScript = buildVerifiedBinaryInstallScript(server, sudo, serviceName, tempBinPath, tempServicePath, tempKeysPath, tempScriptPath)
 	}
 
 	uploads = append(uploads, BootstrapUpload{
@@ -125,7 +199,10 @@ func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPasswor
 		Content: []byte(installScript),
 	})
 
-	executor := sshBootstrapExecutor{networkDialContext: a.NetworkDialContext}
+	executor := a.BootstrapExecutor
+	if executor == nil {
+		executor = sshBootstrapExecutor{networkDialContext: a.NetworkDialContext}
+	}
 	req := BootstrapRequest{
 		Address:        server.Address,
 		Port:           loginPort,
@@ -149,10 +226,11 @@ func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPasswor
 		// key prompts the operator (y/N) instead of hard-failing — an explicit,
 		// non-silent re-pin path. nil keeps the fail-closed default above.
 		HostKeyChangedPrompt: a.HostKeyChangedPrompt,
+		AgentRelease:         agentRelease,
 		Uploads:              uploads,
 		RunCommand:           "/bin/sh " + shellQuote(tempScriptPath),
 	}
-	if err := executor.Bootstrap(context.Background(), req); err != nil {
+	if err := executor.Bootstrap(ctx, req); err != nil {
 		return fmt.Errorf("agent install: %w", err)
 	}
 
@@ -160,6 +238,7 @@ func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPasswor
 	server.Port = agentPort
 	server.Agent = AgentInstall{
 		Managed:     true,
+		Status:      "managed",
 		BinaryPath:  defaultAgentBinaryPath,
 		ServiceName: serviceName,
 		LoginUser:   loginUser,
@@ -169,14 +248,45 @@ func (a *App) AutoInstallAgent(serverName, loginUser, loginKeyPath, loginPasswor
 		UpdatedAt:   time.Now().UTC(),
 	}
 	if err := a.SaveServer(server); err != nil {
-		return err
+		return &AgentInstallCompletionError{
+			ManagedStateSaved: false,
+			Err:               fmt.Errorf("save managed state: %w", err),
+		}
 	}
-	return a.AuditLog.Append(logs.AuditEntry{
+	installComplete = true
+	if err := a.AuditLog.Append(logs.AuditEntry{
 		Action:   "agent.install",
 		Target:   serverName,
 		Operator: a.operator(),
 		Details:  fmt.Sprintf("version=%s service=%s port=%d login=%s:%d", version.Version, serviceName, agentPort, loginUser, loginPort),
-	})
+	}); err != nil {
+		return &AgentInstallCompletionError{ManagedStateSaved: true, Err: err}
+	}
+	return nil
+}
+
+func (a *App) recordAgentInstallProblem(serverName, status string, cause error) error {
+	server, err := a.GetServer(serverName)
+	if err != nil {
+		return err
+	}
+	server.Agent.Managed = false
+	server.Agent.Status = status
+	server.Agent.LastError = boundedAgentInstallError(cause)
+	server.Agent.UpdatedAt = time.Now().UTC()
+	return a.SaveServer(server)
+}
+
+func boundedAgentInstallError(err error) string {
+	if err == nil {
+		return ""
+	}
+	const maxLen = 2048
+	message := strings.TrimSpace(err.Error())
+	if len(message) <= maxLen {
+		return message
+	}
+	return message[:maxLen-3] + "..."
 }
 
 // TeardownAgent SSHes to the server using stored login credentials and removes the managed agent.
@@ -270,13 +380,17 @@ func AgentInstallInstructions(server ServerRecord, mode transport.Mode) string {
 			server.Name, ver, agentGitHubRepo, enrollSetup, server.Name, note,
 		)
 	default:
+		agentPort := server.Port
+		if agentPort == 0 {
+			agentPort = 2222
+		}
 		return fmt.Sprintf(
 			"To install the agent on %s, download fleet-agent_%s for your OS/arch from\n"+
 				"https://github.com/%s/releases and run:\n\n"+
-				"  fleet-agent serve --listen 0.0.0.0:2222\n\n"+
-				"Add it to your init system and ensure port 2222 is reachable.\n"+
+				"  fleet-agent serve --listen 0.0.0.0:%d\n\n"+
+				"Add it to your init system and ensure port %d is reachable.\n"+
 				"Then run: fleet server reconnect %s",
-			server.Name, ver, agentGitHubRepo, server.Name,
+			server.Name, ver, agentGitHubRepo, agentPort, agentPort, server.Name,
 		)
 	}
 }
@@ -292,113 +406,195 @@ var agentLinuxTargets = []agentLinuxTarget{
 	{name: "linux-armv7", arch: "armv7"},
 }
 
-type agentArtifactDownloader func(context.Context, string) ([]byte, error)
+const (
+	maxAgentArtifactBytes             = 512 << 20
+	maxRemoteAgentManifestBytes       = 8 << 20
+	maxAgentSignatureBytes            = 1 << 20
+	remoteAgentDownloadTimeoutSeconds = 300
+)
 
-const maxAgentArtifactBytes = 512 << 20
-
-func downloadVerifiedAgentBinaries(ctx context.Context, rawVersion string, downloader agentArtifactDownloader) (map[string][]byte, error) {
-	manifest, err := update.Fetch(ctx, update.DefaultManifestURL)
-	if err != nil {
-		return nil, fmt.Errorf("fetch release manifest: %w", err)
-	}
-	if downloader == nil {
-		downloader = downloadApprovedAgentURL
-	}
-	return verifyAgentBinaries(ctx, rawVersion, manifest, downloader, update.SigningPublicKey())
+type remoteOutputRunner interface {
+	Output(context.Context, string, int64) ([]byte, error)
 }
 
-func verifyAgentBinaries(ctx context.Context, rawVersion string, manifest update.Manifest, downloader agentArtifactDownloader, publicKeyText string) (map[string][]byte, error) {
-	versionTag := strings.TrimSpace(rawVersion)
-	if !strings.HasPrefix(versionTag, "v") {
-		versionTag = "v" + versionTag
+type selectedAgentRelease struct {
+	versionTag string
+	target     agentLinuxTarget
+	info       update.BinaryInfo
+}
+
+func agentTargetForUname(system, machine string) (agentLinuxTarget, error) {
+	if !strings.EqualFold(strings.TrimSpace(system), "linux") {
+		return agentLinuxTarget{}, fmt.Errorf("agent auto-install supports Linux targets only, got %q", strings.TrimSpace(system))
 	}
-	versionNoV := strings.TrimPrefix(versionTag, "v")
-	if versionNoV == "" || strings.ContainsAny(versionNoV, "/\\_") {
-		return nil, fmt.Errorf("invalid agent release version %q", rawVersion)
+	switch strings.ToLower(strings.TrimSpace(machine)) {
+	case "x86_64", "amd64":
+		return agentLinuxTargets[0], nil
+	case "aarch64", "arm64":
+		return agentLinuxTargets[1], nil
+	case "armv7l", "armv7":
+		return agentLinuxTargets[2], nil
+	default:
+		return agentLinuxTarget{}, fmt.Errorf("unsupported Linux architecture %q", strings.TrimSpace(machine))
+	}
+}
+
+func selectAgentRelease(rawVersion string, target agentLinuxTarget, manifest update.Manifest) (selectedAgentRelease, error) {
+	versionTag, ok := version.NormalizeSemVer(rawVersion)
+	if !ok {
+		return selectedAgentRelease{}, fmt.Errorf("invalid agent release version %q", rawVersion)
 	}
 	entries, ok := manifest.AgentBinaries[versionTag]
 	if !ok {
-		return nil, fmt.Errorf("agent release %s is absent from manifest", versionTag)
+		return selectedAgentRelease{}, fmt.Errorf("agent release %s is absent from manifest", versionTag)
+	}
+	info, ok := entries[target.name]
+	if !ok {
+		return selectedAgentRelease{}, fmt.Errorf("agent release %s is missing target %s", versionTag, target.name)
+	}
+	versionNoV := strings.TrimPrefix(versionTag, "v")
+	expectedURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/fleet-agent_%s_linux_%s.tar.gz", agentGitHubRepo, versionTag, versionNoV, target.arch)
+	if info.URL != expectedURL || info.Signature != expectedURL+".minisig" {
+		return selectedAgentRelease{}, fmt.Errorf("agent %s URLs are not bound to product, version, and target", target.name)
+	}
+	expectedDigest, err := hex.DecodeString(info.SHA256)
+	if err != nil || len(expectedDigest) != sha256.Size || info.Size <= 0 || info.Size > maxAgentArtifactBytes {
+		return selectedAgentRelease{}, fmt.Errorf("agent %s has invalid checksum or size metadata", target.name)
+	}
+	return selectedAgentRelease{versionTag: versionTag, target: target, info: info}, nil
+}
+
+func verifySelectedAgentRelease(selected selectedAgentRelease, archive, signature []byte, publicKeyText string) ([]byte, error) {
+	if int64(len(archive)) != selected.info.Size {
+		return nil, fmt.Errorf("agent %s size mismatch", selected.target.name)
 	}
 	var publicKey minisign.PublicKey
 	if err := publicKey.UnmarshalText([]byte(strings.TrimSpace(publicKeyText))); err != nil {
 		return nil, fmt.Errorf("parse embedded minisign key: %w", err)
 	}
-
-	verified := make(map[string][]byte, len(agentLinuxTargets))
-	for _, target := range agentLinuxTargets {
-		info, ok := entries[target.name]
-		if !ok {
-			return nil, fmt.Errorf("incomplete agent release matrix: missing %s", target.name)
-		}
-		expectedURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/fleet-agent_%s_linux_%s.tar.gz", agentGitHubRepo, versionTag, versionNoV, target.arch)
-		if info.URL != expectedURL || info.Signature != expectedURL+".minisig" {
-			return nil, fmt.Errorf("agent %s URLs are not bound to product, version, and target", target.name)
-		}
-		if len(info.SHA256) != sha256.Size*2 || info.Size <= 0 || info.Size > maxAgentArtifactBytes {
-			return nil, fmt.Errorf("agent %s has invalid checksum or size metadata", target.name)
-		}
-		archive, err := downloader(ctx, info.URL)
-		if err != nil {
-			return nil, fmt.Errorf("download %s: %w", target.name, err)
-		}
-		if int64(len(archive)) != info.Size {
-			return nil, fmt.Errorf("agent %s size mismatch", target.name)
-		}
-		signature, err := downloader(ctx, info.Signature)
-		if err != nil {
-			return nil, fmt.Errorf("download %s signature: %w", target.name, err)
-		}
-		if !minisign.Verify(publicKey, archive, signature) {
-			return nil, fmt.Errorf("agent %s signature verification failed", target.name)
-		}
-		var parsed minisign.Signature
-		if err := parsed.UnmarshalText(signature); err != nil {
-			return nil, fmt.Errorf("parse %s signature: %w", target.name, err)
-		}
-		expectedComment := fmt.Sprintf("cenvero-fleet fleet-agent %s %s", versionTag, target.name)
-		if parsed.TrustedComment != expectedComment {
-			return nil, fmt.Errorf("agent %s signature binding mismatch", target.name)
-		}
-		digest := sha256.Sum256(archive)
-		if !strings.EqualFold(hex.EncodeToString(digest[:]), info.SHA256) {
-			return nil, fmt.Errorf("agent %s checksum mismatch", target.name)
-		}
-		binary, err := extractVerifiedAgentBinary(archive)
-		if err != nil {
-			return nil, fmt.Errorf("extract %s: %w", target.name, err)
-		}
-		verified[target.name] = binary
+	if !minisign.Verify(publicKey, archive, signature) {
+		return nil, fmt.Errorf("agent %s signature verification failed", selected.target.name)
 	}
-	return verified, nil
+	var parsed minisign.Signature
+	if err := parsed.UnmarshalText(signature); err != nil {
+		return nil, fmt.Errorf("parse %s signature: %w", selected.target.name, err)
+	}
+	expectedComment := fmt.Sprintf("cenvero-fleet fleet-agent %s %s", selected.versionTag, selected.target.name)
+	if parsed.TrustedComment != expectedComment {
+		return nil, fmt.Errorf("agent %s signature binding mismatch", selected.target.name)
+	}
+	digest := sha256.Sum256(archive)
+	if !strings.EqualFold(hex.EncodeToString(digest[:]), selected.info.SHA256) {
+		return nil, fmt.Errorf("agent %s checksum mismatch", selected.target.name)
+	}
+	binary, err := extractVerifiedAgentBinary(archive)
+	if err != nil {
+		return nil, fmt.Errorf("extract %s: %w", selected.target.name, err)
+	}
+	return binary, nil
 }
 
-func downloadApprovedAgentURL(ctx context.Context, rawURL string) ([]byte, error) {
-	if err := validateAgentReleaseURL(rawURL); err != nil {
-		return nil, err
+func fetchVerifiedAgentRelease(ctx context.Context, runner remoteOutputRunner, spec BootstrapAgentRelease) ([]byte, error) {
+	return fetchVerifiedAgentReleaseWithKey(ctx, runner, spec, update.SigningPublicKey())
+}
+
+func fetchVerifiedAgentReleaseWithKey(ctx context.Context, runner remoteOutputRunner, spec BootstrapAgentRelease, publicKeyText string) ([]byte, error) {
+	uname, err := runner.Output(ctx, "uname -s && uname -m", 4<<10)
+	if err != nil {
+		return nil, fmt.Errorf("detect target architecture: %w", err)
 	}
-	data, err := update.DownloadApprovedURL(ctx, rawURL,
-		"github.com", "release-assets.githubusercontent.com", "objects.githubusercontent.com")
+	fields := strings.Fields(string(uname))
+	if len(fields) != 2 {
+		return nil, fmt.Errorf("unexpected uname output %q", strings.TrimSpace(string(uname)))
+	}
+	target, err := agentTargetForUname(fields[0], fields[1])
 	if err != nil {
 		return nil, err
 	}
-	if len(data) > maxAgentArtifactBytes {
-		return nil, fmt.Errorf("release payload exceeds %d bytes", maxAgentArtifactBytes)
+
+	manifestData, err := runner.Output(ctx, buildRemoteAgentDownloadCommand(update.DefaultManifestURL, maxRemoteAgentManifestBytes), maxRemoteAgentManifestBytes)
+	if err != nil {
+		return nil, fmt.Errorf("target download release manifest: %w", err)
 	}
-	return data, nil
+	var manifest update.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return nil, fmt.Errorf("decode target-downloaded release manifest: %w", err)
+	}
+	selected, err := selectAgentRelease(spec.Version, target, manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := runner.Output(ctx, buildRemoteAgentDownloadCommand(selected.info.URL, selected.info.Size), selected.info.Size)
+	if err != nil {
+		return nil, fmt.Errorf("target download %s: %w", target.name, err)
+	}
+	signature, err := runner.Output(ctx, buildRemoteAgentDownloadCommand(selected.info.Signature, maxAgentSignatureBytes), maxAgentSignatureBytes)
+	if err != nil {
+		return nil, fmt.Errorf("target download %s signature: %w", target.name, err)
+	}
+	return verifySelectedAgentRelease(selected, archive, signature, publicKeyText)
 }
 
-func validateAgentReleaseURL(rawURL string) error {
-	parsed, err := url.Parse(rawURL)
-	if err != nil || parsed.Scheme != "https" || parsed.User != nil {
-		return fmt.Errorf("refusing non-HTTPS or credentialed release URL")
+func buildRemoteAgentDownloadCommand(rawURL string, maxBytes int64) string {
+	return buildRemoteAgentDownloadCommandWithTimeout(rawURL, maxBytes, remoteAgentDownloadTimeoutSeconds)
+}
+
+func buildRemoteAgentDownloadCommandWithTimeout(rawURL string, maxBytes int64, timeoutSeconds int) string {
+	if maxBytes <= 0 {
+		maxBytes = 1
 	}
-	switch strings.ToLower(parsed.Hostname()) {
-	case "github.com", "release-assets.githubusercontent.com", "objects.githubusercontent.com":
-		return nil
-	default:
-		return fmt.Errorf("refusing unapproved release host %q", parsed.Hostname())
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 1
 	}
+	fileBlocks := maxBytes / 512
+	if maxBytes%512 != 0 {
+		fileBlocks++
+	}
+	return strings.Join([]string{
+		"set -eu",
+		"umask 077",
+		"URL=" + shellQuote(rawURL),
+		"MAX_BLOCKS=" + strconv.FormatInt(fileBlocks, 10),
+		"DEADLINE_SECONDS=" + strconv.Itoa(timeoutSeconds),
+		"TMP=$(mktemp)",
+		"DOWNLOAD_PID=",
+		"WATCHDOG_PID=",
+		`cleanup() {`,
+		`  status=$?`,
+		`  trap - 0 1 2 15`,
+		`  if [ -n "$DOWNLOAD_PID" ]; then kill "$DOWNLOAD_PID" 2>/dev/null || true; wait "$DOWNLOAD_PID" 2>/dev/null || true; fi`,
+		`  if [ -n "$WATCHDOG_PID" ]; then kill "$WATCHDOG_PID" 2>/dev/null || true; wait "$WATCHDOG_PID" 2>/dev/null || true; fi`,
+		`  rm -f "$TMP"`,
+		`  exit "$status"`,
+		`}`,
+		`trap cleanup 0`,
+		`trap 'exit 124' 1 2 15`,
+		`ulimit -f "$MAX_BLOCKS"`,
+		`( remaining=$DEADLINE_SECONDS; while [ "$remaining" -gt 0 ]; do sleep 1; remaining=$((remaining - 1)); done; kill -TERM "$$" 2>/dev/null || true ) &`,
+		`WATCHDOG_PID=$!`,
+		`run_download() {`,
+		`  "$@" &`,
+		`  DOWNLOAD_PID=$!`,
+		`  status=0`,
+		`  wait "$DOWNLOAD_PID" || status=$?`,
+		`  DOWNLOAD_PID=`,
+		`  return "$status"`,
+		`}`,
+		"DOWNLOADED=0",
+		`if command -v wget >/dev/null 2>&1; then`,
+		`  WGET_ATTEMPT=1`,
+		`  while [ "$WGET_ATTEMPT" -le 3 ]; do`,
+		`    if run_download wget -q -T 30 -O "$TMP" "$URL"; then DOWNLOADED=1; break; fi`,
+		`    WGET_ATTEMPT=$((WGET_ATTEMPT + 1))`,
+		`  done`,
+		"fi",
+		`if [ "$DOWNLOADED" -ne 1 ] && command -v curl >/dev/null 2>&1; then`,
+		`  if run_download curl -fL --silent --show-error --retry 3 --retry-delay 1 --connect-timeout 15 --max-time "$DEADLINE_SECONDS" --proto '=https' -o "$TMP" "$URL"; then DOWNLOADED=1; fi`,
+		"fi",
+		`if [ "$DOWNLOADED" -ne 1 ]; then echo "wget and curl could not download the Fleet release payload" >&2; exit 1; fi`,
+		`cat "$TMP"`,
+	}, "\n")
 }
 
 func extractVerifiedAgentBinary(archive []byte) ([]byte, error) {
@@ -431,28 +627,24 @@ func extractVerifiedAgentBinary(archive []byte) ([]byte, error) {
 	return nil, fmt.Errorf("fleet-agent binary not found in archive")
 }
 
-func buildVerifiedBinaryInstallScript(server ServerRecord, sudo, serviceName string, tempBins map[string]string, tempServicePath, tempKeysPath, tempScriptPath string) string {
+func buildVerifiedBinaryInstallScript(server ServerRecord, sudo, serviceName, tempBinPath, tempServicePath, tempKeysPath, tempScriptPath string) string {
 	lines := []string{
-		"#!/bin/sh", "set -eu",
+		"#!/bin/sh",
+		"set -eu",
 		"SERVICE_NAME=" + shellQuote(serviceName),
 		"STATE_DIR=" + shellQuote(defaultStateDir),
 		"CONFIG_DIR=" + shellQuote(defaultConfigDir),
 		"BIN_DIR=" + shellQuote(defaultAgentBinDir),
 		"BIN_PATH=" + shellQuote(defaultAgentBinaryPath),
-		"AMD64_BIN=" + shellQuote(tempBins["linux-amd64"]),
-		"ARM64_BIN=" + shellQuote(tempBins["linux-arm64"]),
-		"ARMV7_BIN=" + shellQuote(tempBins["linux-armv7"]),
-		"case \"$(uname -m)\" in",
-		"  x86_64|amd64) SOURCE=\"$AMD64_BIN\" ;;",
-		"  aarch64|arm64) SOURCE=\"$ARM64_BIN\" ;;",
-		"  armv7l|armv7) SOURCE=\"$ARMV7_BIN\" ;;",
-		"  *) echo \"unsupported architecture\" >&2; exit 1 ;;",
-		"esac",
+		"TEMP_BIN=" + shellQuote(tempBinPath),
+		"TEMP_SERVICE=" + shellQuote(tempServicePath),
+		"TEMP_KEYS=" + shellQuote(tempKeysPath),
+		"TEMP_SCRIPT=" + shellQuote(tempScriptPath),
+		`trap 'rm -f "$TEMP_BIN" "$TEMP_SERVICE" "$TEMP_KEYS" "$TEMP_SCRIPT"' 0 1 2 15`,
 	}
-	lines = append(lines, buildAgentSetupLines(sudo, serviceName, "\"$SOURCE\"", tempServicePath, tempKeysPath)...)
+	lines = append(lines, buildAgentSetupLines(sudo, serviceName, `"$TEMP_BIN"`, tempServicePath, tempKeysPath)...)
 	lines = append(lines,
-		"rm -f "+shellQuote(tempServicePath)+" "+shellQuote(tempKeysPath)+" "+shellQuote(tempScriptPath)+" \"$AMD64_BIN\" \"$ARM64_BIN\" \"$ARMV7_BIN\"",
-		"echo \""+version.ProductName+" agent installed on "+server.Name+" (controller-verified artifact)\"",
+		"echo \""+version.ProductName+" agent installed on "+server.Name+" (target-downloaded, controller-verified artifact)\"",
 	)
 	return strings.Join(lines, "\n") + "\n"
 }

--- a/internal/core/agent_install_test.go
+++ b/internal/core/agent_install_test.go
@@ -11,13 +11,55 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"aead.dev/minisign"
+	"github.com/cenvero/fleet/internal/logs"
+	"github.com/cenvero/fleet/internal/transport"
 	"github.com/cenvero/fleet/internal/update"
+	"github.com/cenvero/fleet/internal/version"
 )
 
-func TestVerifyAgentBinariesRequiresSignedCompleteBoundMatrix(t *testing.T) {
+type fakeRemoteOutputRunner struct {
+	uname      string
+	manifest   []byte
+	archive    []byte
+	signature  []byte
+	archiveURL string
+	calls      []string
+}
+
+func (f *fakeRemoteOutputRunner) Output(_ context.Context, command string, limit int64) ([]byte, error) {
+	f.calls = append(f.calls, command)
+	var data []byte
+	switch {
+	case command == "uname -s && uname -m":
+		data = []byte(f.uname)
+	case strings.Contains(command, update.DefaultManifestURL):
+		data = f.manifest
+	case strings.Contains(command, f.archiveURL+".minisig"):
+		data = f.signature
+	case strings.Contains(command, f.archiveURL):
+		data = f.archive
+	default:
+		return nil, fmt.Errorf("unexpected remote command: %s", command)
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("remote output exceeds %d bytes", limit)
+	}
+	return append([]byte(nil), data...), nil
+}
+
+func agentReleaseFixture(t *testing.T, target agentLinuxTarget, trustedComment string) (update.Manifest, []byte, []byte, string, []byte) {
+	t.Helper()
 	pub, priv, err := minisign.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -26,65 +68,381 @@ func TestVerifyAgentBinariesRequiresSignedCompleteBoundMatrix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manifest := update.Manifest{AgentBinaries: map[string]map[string]update.BinaryInfo{"v1.2.3": {}}}
-	payloads := map[string][]byte{}
-	for _, target := range agentLinuxTargets {
-		archive := agentTestArchive(t, []byte("binary-"+target.name))
-		sum := sha256.Sum256(archive)
-		url := "https://github.com/cenvero/fleet/releases/download/v1.2.3/fleet-agent_1.2.3_linux_" + target.arch + ".tar.gz"
-		sigURL := url + ".minisig"
-		manifest.AgentBinaries["v1.2.3"][target.name] = update.BinaryInfo{
-			URL: url, Signature: sigURL, SHA256: hex.EncodeToString(sum[:]), Size: int64(len(archive)),
-		}
-		payloads[url] = archive
-		payloads[sigURL] = minisign.SignWithComments(priv, archive, "cenvero-fleet fleet-agent v1.2.3 "+target.name, "test")
+	binary := []byte("binary-" + target.name)
+	archive := agentTestArchive(t, binary)
+	sum := sha256.Sum256(archive)
+	url := "https://github.com/cenvero/fleet/releases/download/v1.2.3/fleet-agent_1.2.3_linux_" + target.arch + ".tar.gz"
+	manifest := update.Manifest{AgentBinaries: map[string]map[string]update.BinaryInfo{
+		"v1.2.3": {
+			target.name: {URL: url, Signature: url + ".minisig", SHA256: hex.EncodeToString(sum[:]), Size: int64(len(archive))},
+		},
+	}}
+	if trustedComment == "" {
+		trustedComment = "cenvero-fleet fleet-agent v1.2.3 " + target.name
 	}
-	downloader := func(_ context.Context, url string) ([]byte, error) { return payloads[url], nil }
-	got, err := verifyAgentBinaries(context.Background(), "1.2.3", manifest, downloader, string(pubText))
+	signature := minisign.SignWithComments(priv, archive, trustedComment, "test")
+	return manifest, archive, signature, string(pubText), binary
+}
+
+func TestAgentTargetForUname(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"x86_64":  "linux-amd64",
+		"amd64":   "linux-amd64",
+		"aarch64": "linux-arm64",
+		"arm64":   "linux-arm64",
+		"armv7l":  "linux-armv7",
+		"armv7":   "linux-armv7",
+	}
+	for machine, want := range tests {
+		target, err := agentTargetForUname("Linux", machine)
+		if err != nil || target.name != want {
+			t.Fatalf("agentTargetForUname(Linux,%s)=(%+v,%v), want %s", machine, target, err, want)
+		}
+	}
+	if _, err := agentTargetForUname("Darwin", "arm64"); err == nil {
+		t.Fatal("non-Linux target unexpectedly accepted")
+	}
+	if _, err := agentTargetForUname("Linux", "s390x"); err == nil {
+		t.Fatal("unsupported Linux architecture unexpectedly accepted")
+	}
+}
+
+func TestFetchVerifiedAgentReleaseDownloadsOnlyDetectedTarget(t *testing.T) {
+	target := agentLinuxTargets[0]
+	manifest, archive, signature, pubText, wantBinary := agentReleaseFixture(t, target, "")
+	manifestData, err := json.Marshal(manifest)
 	if err != nil {
-		t.Fatalf("verifyAgentBinaries() error = %v", err)
-	}
-	if len(got) != len(agentLinuxTargets) {
-		t.Fatalf("verified %d binaries, want %d", len(got), len(agentLinuxTargets))
-	}
-
-	delete(manifest.AgentBinaries["v1.2.3"], "linux-armv7")
-	if _, err := verifyAgentBinaries(context.Background(), "1.2.3", manifest, downloader, string(pubText)); err == nil {
-		t.Fatal("expected incomplete agent matrix to fail closed")
-	}
-}
-
-func TestVerifyAgentBinariesRejectsWrongTrustedBinding(t *testing.T) {
-	pub, priv, _ := minisign.GenerateKey(rand.Reader)
-	pubText, _ := pub.MarshalText()
-	manifest := update.Manifest{AgentBinaries: map[string]map[string]update.BinaryInfo{"v1.2.3": {}}}
-	payloads := map[string][]byte{}
-	for _, target := range agentLinuxTargets {
-		archive := agentTestArchive(t, []byte(target.name))
-		sum := sha256.Sum256(archive)
-		url := "https://github.com/cenvero/fleet/releases/download/v1.2.3/fleet-agent_1.2.3_linux_" + target.arch + ".tar.gz"
-		manifest.AgentBinaries["v1.2.3"][target.name] = update.BinaryInfo{URL: url, Signature: url + ".minisig", SHA256: hex.EncodeToString(sum[:]), Size: int64(len(archive))}
-		payloads[url] = archive
-		comment := "cenvero-fleet fleet-agent v1.2.3 " + target.name
-		if target.name == "linux-amd64" {
-			comment = "cenvero-fleet fleet-agent v9.9.9 linux-amd64"
-		}
-		payloads[url+".minisig"] = minisign.SignWithComments(priv, archive, comment, "test")
-	}
-	downloader := func(_ context.Context, url string) ([]byte, error) { return payloads[url], nil }
-	if _, err := verifyAgentBinaries(context.Background(), "v1.2.3", manifest, downloader, string(pubText)); err == nil {
-		t.Fatal("expected wrong trusted comment binding to fail closed")
-	}
-}
-
-func TestValidateAgentReleaseURL(t *testing.T) {
-	for _, raw := range []string{"http://github.com/a", "https://example.com/a", "file:///tmp/a", "https://user@github.com/a"} {
-		if err := validateAgentReleaseURL(raw); err == nil {
-			t.Fatalf("expected %q to be rejected", raw)
-		}
-	}
-	if err := validateAgentReleaseURL("https://release-assets.githubusercontent.com/a"); err != nil {
 		t.Fatal(err)
+	}
+	runner := &fakeRemoteOutputRunner{
+		uname: "Linux\nx86_64\n", manifest: manifestData, archive: archive,
+		signature: signature, archiveURL: manifest.AgentBinaries["v1.2.3"][target.name].URL,
+	}
+	got, err := fetchVerifiedAgentReleaseWithKey(context.Background(), runner, BootstrapAgentRelease{Version: "1.2.3"}, pubText)
+	if err != nil {
+		t.Fatalf("fetchVerifiedAgentReleaseWithKey() error = %v", err)
+	}
+	if !bytes.Equal(got, wantBinary) {
+		t.Fatalf("verified binary=%q, want %q", got, wantBinary)
+	}
+	if len(runner.calls) != 4 {
+		t.Fatalf("remote calls=%d, want uname + manifest + archive + signature: %#v", len(runner.calls), runner.calls)
+	}
+	joined := strings.Join(runner.calls, "\n")
+	if strings.Contains(joined, "linux_arm64") || strings.Contains(joined, "linux_armv7") {
+		t.Fatalf("unrelated architecture was requested: %s", joined)
+	}
+	if strings.Index(runner.calls[1], "command -v wget") > strings.Index(runner.calls[1], "command -v curl") {
+		t.Fatalf("target downloader does not prefer wget before curl: %s", runner.calls[1])
+	}
+	for _, want := range []string{"WGET_ATTEMPT=1", `while [ "$WGET_ATTEMPT" -le 3 ]`, "wget -q -T 30", "curl -fL", "--retry 3", "--proto '=https'"} {
+		if !strings.Contains(runner.calls[1], want) {
+			t.Fatalf("target downloader missing %q: %s", want, runner.calls[1])
+		}
+	}
+	if strings.Contains(runner.calls[1], "wget -q -t") {
+		t.Fatalf("target downloader uses GNU-only wget retry flag: %s", runner.calls[1])
+	}
+}
+
+func TestSelectedAgentReleaseFailsClosed(t *testing.T) {
+	target := agentLinuxTargets[0]
+	manifest, archive, signature, pubText, _ := agentReleaseFixture(t, target, "")
+	selected, err := selectAgentRelease("v1.2.3", target, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	badHash := selected
+	badHash.info.SHA256 = strings.Repeat("0", sha256.Size*2)
+	if _, err := verifySelectedAgentRelease(badHash, archive, signature, pubText); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("checksum tampering error=%v", err)
+	}
+	if _, err := verifySelectedAgentRelease(selected, archive[:len(archive)-1], signature, pubText); err == nil || !strings.Contains(err.Error(), "size mismatch") {
+		t.Fatalf("short archive error=%v", err)
+	}
+	if _, err := verifySelectedAgentRelease(selected, archive, []byte("not a minisign signature"), pubText); err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("invalid signature error=%v", err)
+	}
+
+	wrongManifest, wrongArchive, wrongBinding, wrongPub, _ := agentReleaseFixture(t, target, "cenvero-fleet fleet-agent v9.9.9 linux-amd64")
+	wrongSelected, err := selectAgentRelease("v1.2.3", target, wrongManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifySelectedAgentRelease(wrongSelected, wrongArchive, wrongBinding, wrongPub); err == nil || !strings.Contains(err.Error(), "signature binding mismatch") {
+		t.Fatalf("wrong trusted comment error=%v", err)
+	}
+	badChecksumManifest := update.Manifest{AgentBinaries: map[string]map[string]update.BinaryInfo{
+		"v1.2.3": {target.name: selected.info},
+	}}
+	badChecksumEntry := badChecksumManifest.AgentBinaries["v1.2.3"][target.name]
+	badChecksumEntry.SHA256 = strings.Repeat("z", sha256.Size*2)
+	badChecksumManifest.AgentBinaries["v1.2.3"][target.name] = badChecksumEntry
+	if _, err := selectAgentRelease("v1.2.3", target, badChecksumManifest); err == nil || !strings.Contains(err.Error(), "invalid checksum") {
+		t.Fatalf("malformed checksum metadata error=%v", err)
+	}
+	if _, err := selectAgentRelease("v1.2.3", target, update.Manifest{AgentBinaries: map[string]map[string]update.BinaryInfo{"v1.2.3": {}}}); err == nil || !strings.Contains(err.Error(), "missing target") {
+		t.Fatalf("missing target error=%v", err)
+	}
+
+	badManifest := manifest
+	entry := badManifest.AgentBinaries["v1.2.3"][target.name]
+	entry.URL = "https://example.com/agent.tar.gz"
+	badManifest.AgentBinaries["v1.2.3"][target.name] = entry
+	if _, err := selectAgentRelease("v1.2.3", target, badManifest); err == nil {
+		t.Fatal("unbound manifest URL unexpectedly accepted")
+	}
+}
+
+func TestFetchVerifiedAgentReleaseStopsBeforeArtifactOnInvalidManifest(t *testing.T) {
+	manifest := update.Manifest{AgentBinaries: map[string]map[string]update.BinaryInfo{"v1.2.3": {}}}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRemoteOutputRunner{uname: "Linux\nx86_64\n", manifest: manifestData}
+	_, err = fetchVerifiedAgentReleaseWithKey(context.Background(), runner, BootstrapAgentRelease{Version: "v1.2.3"}, "invalid key never reached")
+	if err == nil || !strings.Contains(err.Error(), "missing target") {
+		t.Fatalf("error=%v, want missing target", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls=%d, want uname and manifest only: %#v", len(runner.calls), runner.calls)
+	}
+}
+
+func TestRemoteAgentDownloadCommandFallsBackFromWgetToCurl(t *testing.T) {
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "wget"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	curlScript := `#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    printf 'remote-payload' > "$1"
+    exit 0
+  fi
+  shift
+done
+exit 2
+`
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte(curlScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", buildRemoteAgentDownloadCommand("https://example.com/artifact", 1<<20))
+	cmd.Env = append(os.Environ(), "PATH="+binDir+":/usr/bin:/bin")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("remote downloader shell failed: %v", err)
+	}
+	if string(output) != "remote-payload" {
+		t.Fatalf("output=%q, want curl fallback payload", output)
+	}
+}
+
+func TestRemoteAgentDownloadCommandPrefersSuccessfulWget(t *testing.T) {
+	binDir := t.TempDir()
+	curlMarker := filepath.Join(t.TempDir(), "curl-called")
+	wgetScript := `#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-O" ]; then
+    shift
+    printf 'wget-payload' > "$1"
+    exit 0
+  fi
+  shift
+done
+exit 2
+`
+	if err := os.WriteFile(filepath.Join(binDir, "wget"), []byte(wgetScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	curlScript := "#!/bin/sh\nprintf called > \"$CURL_MARKER\"\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte(curlScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", buildRemoteAgentDownloadCommand("https://example.com/artifact", 1<<20))
+	cmd.Env = append(os.Environ(), "PATH="+binDir+":/usr/bin:/bin", "CURL_MARKER="+curlMarker)
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("remote downloader shell failed: %v", err)
+	}
+	if string(output) != "wget-payload" {
+		t.Fatalf("output=%q, want wget payload", output)
+	}
+	if _, err := os.Stat(curlMarker); !os.IsNotExist(err) {
+		t.Fatalf("curl ran after successful wget, stat error=%v", err)
+	}
+}
+
+func TestRemoteAgentDownloadCommandRetriesBusyBoxCompatibleWget(t *testing.T) {
+	binDir := t.TempDir()
+	countPath := filepath.Join(t.TempDir(), "wget-count")
+	curlMarker := filepath.Join(t.TempDir(), "curl-called")
+	wgetScript := `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -q) shift ;;
+    -T) shift 2 ;;
+    -O) out=$2; shift 2 ;;
+    https://*) shift ;;
+    *) exit 64 ;;
+  esac
+done
+count=0
+if [ -f "$COUNT_PATH" ]; then count=$(cat "$COUNT_PATH"); fi
+count=$((count + 1))
+printf '%s' "$count" > "$COUNT_PATH"
+if [ "$count" -lt 3 ]; then exit 1; fi
+printf 'busybox-wget-payload' > "$out"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "wget"), []byte(wgetScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	curlScript := "#!/bin/sh\nprintf called > \"$CURL_MARKER\"\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte(curlScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", buildRemoteAgentDownloadCommand("https://example.com/artifact", 1<<20))
+	cmd.Env = append(os.Environ(), "PATH="+binDir+":/usr/bin:/bin", "COUNT_PATH="+countPath, "CURL_MARKER="+curlMarker)
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("BusyBox-compatible wget retry shell failed: %v", err)
+	}
+	if string(output) != "busybox-wget-payload" {
+		t.Fatalf("output=%q, want BusyBox-compatible wget payload", output)
+	}
+	attempts, err := os.ReadFile(countPath)
+	if err != nil || string(attempts) != "3" {
+		t.Fatalf("wget attempts=%q, err=%v, want 3", attempts, err)
+	}
+	if _, err := os.Stat(curlMarker); !os.IsNotExist(err) {
+		t.Fatalf("curl ran after third wget attempt succeeded, stat error=%v", err)
+	}
+}
+
+func TestRemoteAgentDownloadCommandRejectsOversizedPayloadAndCleansTemp(t *testing.T) {
+	binDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "target-temp-path")
+	wgetScript := `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-O" ]; then
+    shift
+    out=$1
+    break
+  fi
+  shift
+done
+printf '%s' "$out" > "$RECORD_PATH"
+dd if=/dev/zero of="$out" bs=1024 count=8 2>/dev/null
+`
+	if err := os.WriteFile(filepath.Join(binDir, "wget"), []byte(wgetScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", buildRemoteAgentDownloadCommandWithTimeout("https://example.com/oversized", 512, 5))
+	cmd.Env = append(os.Environ(), "PATH="+binDir+":/usr/bin:/bin", "RECORD_PATH="+marker)
+	if output, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("oversized target download unexpectedly succeeded: %q", output)
+	}
+	tmpPath, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read recorded target temp path: %v", err)
+	}
+	if _, err := os.Stat(string(tmpPath)); !os.IsNotExist(err) {
+		t.Fatalf("target temp file was not removed, stat error=%v", err)
+	}
+}
+
+func TestRemoteAgentDownloadCommandAppliesSharedDeadline(t *testing.T) {
+	binDir := t.TempDir()
+	curlMarker := filepath.Join(t.TempDir(), "curl-called")
+	tmpMarker := filepath.Join(t.TempDir(), "target-temp-path")
+	wgetScript := `#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-O" ]; then
+    shift
+    printf '%s' "$1" > "$RECORD_PATH"
+    break
+  fi
+  shift
+done
+exec sleep 10
+`
+	if err := os.WriteFile(filepath.Join(binDir, "wget"), []byte(wgetScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	curlScript := "#!/bin/sh\nprintf called > \"$CURL_MARKER\"\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte(curlScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", buildRemoteAgentDownloadCommandWithTimeout("https://example.com/trickle", 1<<20, 1))
+	cmd.Env = append(os.Environ(), "PATH="+binDir+":/usr/bin:/bin", "CURL_MARKER="+curlMarker, "RECORD_PATH="+tmpMarker)
+	started := time.Now()
+	if output, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("trickling target download unexpectedly succeeded: %q", output)
+	}
+	if elapsed := time.Since(started); elapsed > 4*time.Second {
+		t.Fatalf("shared target download deadline took %s, want <= 4s", elapsed)
+	}
+	if _, err := os.Stat(curlMarker); !os.IsNotExist(err) {
+		t.Fatalf("curl fallback ran after the shared deadline, stat error=%v", err)
+	}
+	tmpPath, err := os.ReadFile(tmpMarker)
+	if err != nil {
+		t.Fatalf("read recorded target temp path: %v", err)
+	}
+	if _, err := os.Stat(string(tmpPath)); !os.IsNotExist(err) {
+		t.Fatalf("interrupted target temp file was not removed, stat error=%v", err)
+	}
+}
+
+func TestAutoInstallReleaseDefersArtifactDownloadToSSHExecutor(t *testing.T) {
+	oldVersion := version.Version
+	version.Version = "v1.2.3"
+	t.Cleanup(func() { version.Version = oldVersion })
+
+	configDir := filepath.Join(t.TempDir(), "fleet")
+	if _, err := Initialize(InitOptions{
+		ConfigDir: configDir, Alias: "fleet", DefaultMode: transport.ModeDirect,
+		CryptoAlgorithm: "ed25519", UpdateChannel: "stable", UpdatePolicy: update.PolicyNotifyOnly,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app, err := Open(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	if err := app.AddServer(ServerRecord{Name: "remote-release", Address: "192.0.2.70", Port: 5911, Mode: transport.ModeDirect}); err != nil {
+		t.Fatal(err)
+	}
+	executor := &failingAgentInstallExecutor{err: errors.New("stop after request capture")}
+	app.BootstrapExecutor = executor
+	err = app.AutoInstallAgentContext(context.Background(), "remote-release", "root", "", "password", 22, false)
+	if err == nil || len(executor.requests) != 1 {
+		t.Fatalf("error=%v requests=%d", err, len(executor.requests))
+	}
+	req := executor.requests[0]
+	if req.AgentRelease == nil || req.AgentRelease.Version != "v1.2.3" || !strings.HasSuffix(req.AgentRelease.DestinationPath, ".bin") {
+		t.Fatalf("release request=%+v", req.AgentRelease)
+	}
+	for _, upload := range req.Uploads {
+		if upload.Path == req.AgentRelease.DestinationPath || strings.Contains(upload.Path, "-amd64.bin") || strings.Contains(upload.Path, "-arm64.bin") || strings.Contains(upload.Path, "-armv7.bin") {
+			t.Fatalf("controller pre-uploaded a release binary: %+v", upload)
+		}
+	}
+	if !strings.Contains(req.RunCommand, ".sh") {
+		t.Fatalf("missing install command: %s", req.RunCommand)
+	}
+	script := string(req.Uploads[len(req.Uploads)-1].Content)
+	if !strings.Contains(script, req.AgentRelease.DestinationPath) || strings.Contains(script, "AMD64_BIN") {
+		t.Fatalf("install script is not single-binary: %s", script)
 	}
 }
 
@@ -106,4 +464,127 @@ func agentTestArchive(t *testing.T, binary []byte) []byte {
 		t.Fatal(err)
 	}
 	return buf.Bytes()
+}
+
+type failingAgentInstallExecutor struct {
+	requests []BootstrapRequest
+	err      error
+}
+
+func (f *failingAgentInstallExecutor) Bootstrap(_ context.Context, req BootstrapRequest) error {
+	f.requests = append(f.requests, req)
+	return f.err
+}
+
+func TestAutoInstallAgentPreservesPortAndRecordsFailure(t *testing.T) {
+	oldVersion := version.Version
+	version.Version = "dev"
+	t.Cleanup(func() { version.Version = oldVersion })
+
+	binDir := t.TempDir()
+	agentBinary := filepath.Join(binDir, "fleet-agent")
+	if err := os.WriteFile(agentBinary, []byte("agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	configDir := filepath.Join(t.TempDir(), "fleet")
+	if _, err := Initialize(InitOptions{
+		ConfigDir: configDir, Alias: "fleet", DefaultMode: transport.ModeDirect,
+		CryptoAlgorithm: "ed25519", UpdateChannel: "stable", UpdatePolicy: update.PolicyNotifyOnly,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app, err := Open(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	if err := app.AddServer(ServerRecord{Name: "herm", Address: "91.99.197.39", Port: 5911, Mode: transport.ModeDirect}); err != nil {
+		t.Fatal(err)
+	}
+
+	executor := &failingAgentInstallExecutor{err: errors.New("remote unavailable")}
+	app.BootstrapExecutor = executor
+	const password = "do-not-persist-this-password"
+	err = app.AutoInstallAgentContext(context.Background(), "herm", "ubuntu", "", password, 2200, true)
+	if err == nil || !strings.Contains(err.Error(), "remote unavailable") {
+		t.Fatalf("AutoInstallAgentContext() error=%v", err)
+	}
+	if len(executor.requests) != 1 {
+		t.Fatalf("bootstrap requests=%d, want 1", len(executor.requests))
+	}
+	req := executor.requests[0]
+	if req.Port != 2200 {
+		t.Fatalf("bootstrap login port=%d, want 2200", req.Port)
+	}
+	serviceUnit := string(req.Uploads[0].Content)
+	if !strings.Contains(serviceUnit, "0.0.0.0:5911") {
+		t.Fatalf("service unit did not preserve configured agent port: %s", serviceUnit)
+	}
+
+	stored, err := app.GetServer("herm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Port != 5911 || stored.Agent.LoginPort != 2200 || stored.Agent.LoginUser != "ubuntu" || !stored.Agent.UseSudo {
+		t.Fatalf("failed install lost retry metadata: %+v", stored)
+	}
+	if stored.Agent.Managed || stored.Agent.Status != "failed" || !strings.Contains(stored.Agent.LastError, "remote unavailable") {
+		t.Fatalf("failed install state=%+v", stored.Agent)
+	}
+	recordData, err := os.ReadFile(filepath.Join(configDir, "servers", "herm.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(recordData), password) {
+		t.Fatal("login password was persisted in the server record")
+	}
+}
+
+func TestAutoInstallAgentAuditFailureDoesNotMisclassifyInstall(t *testing.T) {
+	oldVersion := version.Version
+	version.Version = "dev"
+	t.Cleanup(func() { version.Version = oldVersion })
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "fleet-agent"), []byte("agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	configDir := filepath.Join(t.TempDir(), "fleet")
+	if _, err := Initialize(InitOptions{
+		ConfigDir: configDir, Alias: "fleet", DefaultMode: transport.ModeDirect,
+		CryptoAlgorithm: "ed25519", UpdateChannel: "stable", UpdatePolicy: update.PolicyNotifyOnly,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app, err := Open(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	if err := app.AddServer(ServerRecord{Name: "audit-node", Address: "192.0.2.60", Port: 3022, Mode: transport.ModeDirect}); err != nil {
+		t.Fatal(err)
+	}
+	app.BootstrapExecutor = &fakeBootstrapExecutor{}
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	app.AuditLog = logs.NewAuditLog(filepath.Join(blocker, "audit.log"))
+
+	err = app.AutoInstallAgentContext(context.Background(), "audit-node", "root", "", "", 22, false)
+	var completionErr *AgentInstallCompletionError
+	if !errors.As(err, &completionErr) || !completionErr.ManagedStateSaved {
+		t.Fatalf("error=%v, want managed-state-saved completion error", err)
+	}
+	stored, getErr := app.GetServer("audit-node")
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if !stored.Agent.Managed || stored.Agent.Status != "managed" {
+		t.Fatalf("audit failure misclassified successful install: %+v", stored.Agent)
+	}
 }

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -185,7 +185,13 @@ func (a *App) AddServer(record ServerRecord) error {
 		return fmt.Errorf("invalid server name: %w", err)
 	}
 	if record.Port == 0 {
-		record.Port = 22
+		record.Port = a.Config.Runtime.DefaultAgentPort
+		if record.Port == 0 {
+			record.Port = 2222
+		}
+	}
+	if record.Port < 1 || record.Port > 65535 {
+		return fmt.Errorf("invalid agent port %d: must be 1-65535", record.Port)
 	}
 	if record.User == "" {
 		record.User = "root"
@@ -383,7 +389,7 @@ func (a *App) writeNewServerFile(server ServerRecord) error {
 	}
 	if err := os.Link(tmpPath, path); err != nil {
 		if os.IsExist(err) {
-			return fmt.Errorf("server %q already exists; use an explicit update command or remove it first", server.Name)
+			return fmt.Errorf("server %q already exists; retry its agent setup with 'fleet server bootstrap %s', or remove it with 'fleet server remove %s --force' before adding it again", server.Name, server.Name, server.Name)
 		}
 		return fmt.Errorf("publish server %s: %w", server.Name, err)
 	}

--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	fleetcrypto "github.com/cenvero/fleet/internal/crypto"
@@ -43,6 +44,14 @@ type BootstrapExecutor interface {
 	Bootstrap(context.Context, BootstrapRequest) error
 }
 
+// BootstrapAgentRelease asks the SSH executor to have the target download the
+// exact release matching Version, verify it on the controller, and stage the
+// extracted binary at DestinationPath before RunCommand executes.
+type BootstrapAgentRelease struct {
+	Version         string
+	DestinationPath string
+}
+
 type BootstrapRequest struct {
 	Address          string
 	Port             int
@@ -58,6 +67,7 @@ type BootstrapRequest struct {
 	// nil, the static AcceptNewHostKey behavior applies (refuse a changed key
 	// unless the flag forces a re-pin).
 	HostKeyChangedPrompt func(host, oldFP, newFP string) bool
+	AgentRelease         *BootstrapAgentRelease
 	Uploads              []BootstrapUpload
 	RunCommand           string
 }
@@ -173,6 +183,7 @@ func (a *App) BootstrapServer(name string, opts BootstrapOptions) (BootstrapResu
 	}
 	server.Agent = AgentInstall{
 		Managed:     true,
+		Status:      "managed",
 		BinaryPath:  defaultAgentBinaryPath,
 		ServiceName: resolved.serviceName,
 		LoginUser:   resolved.loginUser,
@@ -226,6 +237,9 @@ type resolvedBootstrapConfig struct {
 func (a *App) resolveBootstrapConfig(server ServerRecord, opts BootstrapOptions) (resolvedBootstrapConfig, error) {
 	loginUser := strings.TrimSpace(opts.LoginUser)
 	if loginUser == "" {
+		loginUser = strings.TrimSpace(server.Agent.LoginUser)
+	}
+	if loginUser == "" {
 		if opts.PrintScript {
 			loginUser = "root"
 		} else {
@@ -235,10 +249,19 @@ func (a *App) resolveBootstrapConfig(server ServerRecord, opts BootstrapOptions)
 
 	loginPort := opts.LoginPort
 	if loginPort == 0 {
-		loginPort = 22
+		loginPort = server.Agent.LoginPort
+		if loginPort == 0 {
+			loginPort = 22
+		}
+	}
+	if loginPort < 1 || loginPort > 65535 {
+		return resolvedBootstrapConfig{}, fmt.Errorf("invalid bootstrap login port %d: must be 1-65535", loginPort)
 	}
 
 	loginKeyPath := strings.TrimSpace(opts.LoginKeyPath)
+	if loginKeyPath == "" {
+		loginKeyPath = strings.TrimSpace(server.Agent.LoginKey)
+	}
 	if loginKeyPath == "" {
 		loginKeyPath = a.serverPrivateKeyPath(server)
 	}
@@ -258,12 +281,15 @@ func (a *App) resolveBootstrapConfig(server ServerRecord, opts BootstrapOptions)
 
 	agentListenAddr := strings.TrimSpace(opts.AgentListenAddr)
 	agentPort := server.Port
-	if agentPort == 0 || agentPort == 22 {
+	if agentPort == 0 {
 		if a.Config.Runtime.DefaultAgentPort > 0 {
 			agentPort = a.Config.Runtime.DefaultAgentPort
 		} else {
 			agentPort = 2222
 		}
+	}
+	if agentPort < 1 || agentPort > 65535 {
+		return resolvedBootstrapConfig{}, fmt.Errorf("invalid agent port %d: must be 1-65535", agentPort)
 	}
 	if agentListenAddr == "" && server.Mode == transport.ModeDirect {
 		agentListenAddr = fmt.Sprintf("0.0.0.0:%d", agentPort)
@@ -390,6 +416,9 @@ func portFromAddress(addr string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("parse agent port %q: %w", portText, err)
 	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("invalid agent port %d: must be 1-65535", port)
+	}
 	return port, nil
 }
 
@@ -492,6 +521,58 @@ type sshBootstrapExecutor struct {
 	networkDialContext func(context.Context, string, string) (net.Conn, error)
 }
 
+func (e sshBootstrapExecutor) connect(ctx context.Context, req BootstrapRequest, authMethods []ssh.AuthMethod) (*ssh.Client, error) {
+	var hostKeyCallback ssh.HostKeyCallback
+	var err error
+	if req.HostKeyChangedPrompt != nil {
+		hostKeyCallback, err = transport.NewInteractiveHostKeyCallback(req.KnownHostsPath, req.HostKeyChangedPrompt, &transport.HostKeyState{})
+	} else {
+		hostKeyCallback, err = transport.NewTOFUHostKeyCallback(req.KnownHostsPath, req.AcceptNewHostKey, &transport.HostKeyState{})
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	address := net.JoinHostPort(req.Address, strconv.Itoa(req.Port))
+	config := &ssh.ClientConfig{
+		Config: ssh.Config{Ciphers: transport.SupportedCiphers()},
+		User:   req.User, Auth: authMethods, HostKeyCallback: hostKeyCallback,
+		Timeout: 10 * time.Second,
+	}
+	var rawConn net.Conn
+	if e.networkDialContext != nil {
+		rawConn, err = e.networkDialContext(ctx, "tcp", address)
+	} else {
+		rawConn, err = (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, "tcp", address)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("dial bootstrap target %s: %w", address, err)
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = rawConn.Close()
+		}
+	}()
+
+	handshakeDeadline := time.Now().Add(config.Timeout)
+	if deadline, ok := ctx.Deadline(); ok && deadline.Before(handshakeDeadline) {
+		handshakeDeadline = deadline
+	}
+	if err := rawConn.SetDeadline(handshakeDeadline); err != nil {
+		return nil, fmt.Errorf("set bootstrap ssh handshake deadline: %w", err)
+	}
+	sshConn, chans, reqs, err := ssh.NewClientConn(rawConn, address, config)
+	if err != nil {
+		return nil, fmt.Errorf("establish bootstrap ssh connection to %s: %w", address, err)
+	}
+	if err := rawConn.SetDeadline(time.Time{}); err != nil {
+		_ = sshConn.Close()
+		return nil, fmt.Errorf("clear bootstrap ssh handshake deadline: %w", err)
+	}
+	closeOnError = false
+	return ssh.NewClient(sshConn, chans, reqs), nil
+}
 func (e sshBootstrapExecutor) Bootstrap(ctx context.Context, req BootstrapRequest) error {
 	var authMethods []ssh.AuthMethod
 	if req.Password != "" {
@@ -508,116 +589,271 @@ func (e sshBootstrapExecutor) Bootstrap(ctx context.Context, req BootstrapReques
 		return fmt.Errorf("bootstrap: no authentication method provided (need --login-key or --login-password)")
 	}
 
-	var hostKeyCallback ssh.HostKeyCallback
-	var err error
-	if req.HostKeyChangedPrompt != nil {
-		// Interactive: pin a new host (TOFU), but prompt — and only re-pin on an
-		// explicit yes — when an existing pin no longer matches.
-		hostKeyCallback, err = transport.NewInteractiveHostKeyCallback(req.KnownHostsPath, req.HostKeyChangedPrompt, &transport.HostKeyState{})
-	} else {
-		hostKeyCallback, err = transport.NewTOFUHostKeyCallback(req.KnownHostsPath, req.AcceptNewHostKey, &transport.HostKeyState{})
-	}
+	client, err := e.connect(ctx, req, authMethods)
 	if err != nil {
 		return err
 	}
-
-	address := net.JoinHostPort(req.Address, strconv.Itoa(req.Port))
-	config := &ssh.ClientConfig{
-		Config: ssh.Config{
-			Ciphers: transport.SupportedCiphers(),
-		},
-		User:            req.User,
-		Auth:            authMethods,
-		HostKeyCallback: hostKeyCallback,
-		Timeout:         10 * time.Second,
-	}
-
-	var rawConn net.Conn
-	if e.networkDialContext != nil {
-		rawConn, err = e.networkDialContext(ctx, "tcp", address)
-	} else {
-		rawConn, err = (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, "tcp", address)
-	}
-	if err != nil {
-		return fmt.Errorf("dial bootstrap target %s: %w", address, err)
-	}
-	defer rawConn.Close()
-
-	handshakeDeadline := time.Now().Add(config.Timeout)
-	if deadline, ok := ctx.Deadline(); ok && deadline.Before(handshakeDeadline) {
-		handshakeDeadline = deadline
-	}
-	if err := rawConn.SetDeadline(handshakeDeadline); err != nil {
-		return fmt.Errorf("set bootstrap ssh handshake deadline: %w", err)
-	}
-	sshConn, chans, reqs, err := ssh.NewClientConn(rawConn, address, config)
-	if err != nil {
-		return fmt.Errorf("establish bootstrap ssh connection to %s: %w", address, err)
-	}
-	if err := rawConn.SetDeadline(time.Time{}); err != nil {
-		_ = sshConn.Close()
-		return fmt.Errorf("clear bootstrap ssh handshake deadline: %w", err)
-	}
-	client := ssh.NewClient(sshConn, chans, reqs)
 	defer client.Close()
 
+	bootstrapSucceeded := false
+	stagedPaths := make([]string, 0, len(req.Uploads)+1)
+	defer func() {
+		if bootstrapSucceeded || len(stagedPaths) == 0 {
+			return
+		}
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), 2*time.Second)
+		cleanupErr := cleanupRemoteStagingFiles(cleanupCtx, client, stagedPaths)
+		cancelCleanup()
+		if cleanupErr == nil {
+			return
+		}
+		reconnectCtx, cancelReconnect := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelReconnect()
+		cleanupClient, err := e.connect(reconnectCtx, req, authMethods)
+		if err != nil {
+			return
+		}
+		defer cleanupClient.Close()
+		_ = cleanupRemoteStagingFiles(reconnectCtx, cleanupClient, stagedPaths)
+	}()
+
+	var releaseUpload *BootstrapUpload
+	if req.AgentRelease != nil {
+		destination := strings.TrimSpace(req.AgentRelease.DestinationPath)
+		if destination == "" {
+			return fmt.Errorf("agent release destination path is required")
+		}
+		for _, upload := range req.Uploads {
+			if upload.Path == destination {
+				return fmt.Errorf("agent release destination %q collides with a bootstrap upload", destination)
+			}
+		}
+		binary, err := fetchVerifiedAgentRelease(ctx, sshRemoteOutputRunner{client: client}, *req.AgentRelease)
+		if err != nil {
+			return fmt.Errorf("target agent release acquisition: %w", err)
+		}
+		releaseUpload = &BootstrapUpload{Path: destination, Mode: 0o700, Content: binary}
+	}
+
 	for _, upload := range req.Uploads {
+		stagedPaths = append(stagedPaths, upload.Path, remoteUploadPartialPath(upload.Path))
 		if err := uploadRemoteFile(ctx, client, upload); err != nil {
 			return err
 		}
 	}
-	return runRemoteCommand(ctx, client, req.RunCommand)
+	if releaseUpload != nil {
+		stagedPaths = append(stagedPaths, releaseUpload.Path, remoteUploadPartialPath(releaseUpload.Path))
+		if err := uploadRemoteFile(ctx, client, *releaseUpload); err != nil {
+			return err
+		}
+	}
+	if err := runRemoteCommand(ctx, client, req.RunCommand); err != nil {
+		return err
+	}
+	bootstrapSucceeded = true
+	return nil
+}
+
+func cleanupRemoteStagingFiles(ctx context.Context, client *ssh.Client, paths []string) error {
+	quoted := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path != "" {
+			quoted = append(quoted, shellQuote(path))
+		}
+	}
+	if len(quoted) == 0 {
+		return nil
+	}
+	return runRemoteCommand(ctx, client, "rm -f "+strings.Join(quoted, " "))
+}
+
+func remoteUploadPartialPath(path string) string {
+	return path + ".part"
+}
+
+func buildRemoteUploadCommand(upload BootstrapUpload) string {
+	return strings.Join([]string{
+		"set -eu",
+		"umask 077",
+		"DEST=" + shellQuote(upload.Path),
+		"PART=" + shellQuote(remoteUploadPartialPath(upload.Path)),
+		"EXPECTED=" + strconv.Itoa(len(upload.Content)),
+		`cleanup_upload() { rm -f "$PART"; }`,
+		`trap cleanup_upload 0`,
+		`trap 'exit 1' 1 2 13 15`,
+		`rm -f "$PART"`,
+		`cat > "$PART"`,
+		`ACTUAL=$(wc -c < "$PART")`,
+		`if [ "$ACTUAL" -ne "$EXPECTED" ]; then echo "incomplete bootstrap upload" >&2; exit 1; fi`,
+		fmt.Sprintf(`chmod %04o "$PART"`, upload.Mode.Perm()),
+		`mv -f "$PART" "$DEST"`,
+		`trap - 0 1 2 13 15`,
+	}, "\n")
 }
 
 func uploadRemoteFile(ctx context.Context, client *ssh.Client, upload BootstrapUpload) error {
-	command := fmt.Sprintf("umask 077 && cat > %s && chmod %04o %s", shellQuote(upload.Path), upload.Mode.Perm(), shellQuote(upload.Path))
-	return runRemoteCommandWithInput(ctx, client, command, bytes.NewReader(upload.Content))
+	return runRemoteCommandWithInput(ctx, client, buildRemoteUploadCommand(upload), bytes.NewReader(upload.Content))
 }
 
 func runRemoteCommand(ctx context.Context, client *ssh.Client, command string) error {
-	return runRemoteCommandWithInput(ctx, client, command, nil)
+	_, _, err := runRemoteCommandCapture(ctx, client, command, nil, 64<<10, 64<<10)
+	return err
 }
 
 func runRemoteCommandWithInput(ctx context.Context, client *ssh.Client, command string, input io.Reader) error {
-	session, err := client.NewSession()
-	if err != nil {
+	_, _, err := runRemoteCommandCapture(ctx, client, command, input, 64<<10, 64<<10)
+	return err
+}
+
+type sshRemoteOutputRunner struct {
+	client *ssh.Client
+}
+
+func (r sshRemoteOutputRunner) Output(ctx context.Context, command string, limit int64) ([]byte, error) {
+	stdout, _, err := runRemoteCommandCapture(ctx, r.client, command, nil, limit, 64<<10)
+	return stdout, err
+}
+
+type boundedCapture struct {
+	mu        sync.Mutex
+	limit     int64
+	data      []byte
+	truncated bool
+}
+
+func newBoundedCapture(limit int64) *boundedCapture {
+	if limit < 0 {
+		limit = 0
+	}
+	return &boundedCapture{limit: limit}
+}
+
+func (b *boundedCapture) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	remaining := b.limit - int64(len(b.data))
+	if remaining > 0 {
+		keep := int64(len(p))
+		if keep > remaining {
+			keep = remaining
+		}
+		b.data = append(b.data, p[:int(keep)]...)
+	}
+	if int64(originalLen) > remaining {
+		b.truncated = true
+	}
+	// Always report the full write so SSH continues draining the channel even
+	// after the retained diagnostic/payload limit has been reached.
+	return originalLen, nil
+}
+
+func (b *boundedCapture) snapshot() ([]byte, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]byte(nil), b.data...), b.truncated
+}
+
+type sshSessionResult struct {
+	session *ssh.Session
+	err     error
+}
+
+func newSSHSessionContext(ctx context.Context, client *ssh.Client) (*ssh.Session, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	result := make(chan sshSessionResult, 1)
+	go func() {
+		session, err := client.NewSession()
+		result <- sshSessionResult{session: session, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		_ = client.Close()
+		return nil, ctx.Err()
+	case opened := <-result:
+		return opened.session, opened.err
+	}
+}
+
+const sshSessionCancelGrace = 250 * time.Millisecond
+
+func closeSSHSessionOnCancel(client *ssh.Client, session *ssh.Session) {
+	closed := make(chan struct{})
+	go func() {
+		_ = session.Close()
+		close(closed)
+	}()
+	timer := time.NewTimer(sshSessionCancelGrace)
+	defer timer.Stop()
+	select {
+	case <-closed:
+	case <-timer.C:
+		_ = client.Close()
+	}
+}
+
+func startSSHSessionContext(ctx context.Context, client *ssh.Client, session *ssh.Session, command string) error {
+	if err := ctx.Err(); err != nil {
+		closeSSHSessionOnCancel(client, session)
 		return err
+	}
+	result := make(chan error, 1)
+	go func() { result <- session.Start(command) }()
+	select {
+	case <-ctx.Done():
+		closeSSHSessionOnCancel(client, session)
+		return ctx.Err()
+	case err := <-result:
+		return err
+	}
+}
+
+func runRemoteCommandCapture(ctx context.Context, client *ssh.Client, command string, input io.Reader, stdoutLimit, stderrLimit int64) ([]byte, []byte, error) {
+	session, err := newSSHSessionContext(ctx, client)
+	if err != nil {
+		return nil, nil, err
 	}
 	defer session.Close()
 
-	var output bytes.Buffer
-	session.Stdout = &output
-	session.Stderr = &output
-
+	stdoutCapture := newBoundedCapture(stdoutLimit)
+	stderrCapture := newBoundedCapture(stderrLimit)
+	session.Stdout = stdoutCapture
+	session.Stderr = stderrCapture
 	if input != nil {
-		stdin, err := session.StdinPipe()
-		if err != nil {
-			return err
-		}
-		go func() {
-			_, _ = io.Copy(stdin, input)
-			_ = stdin.Close()
-		}()
+		session.Stdin = input
+	}
+	if err := startSSHSessionContext(ctx, client, session, command); err != nil {
+		return nil, nil, err
 	}
 
 	done := make(chan error, 1)
-	go func() {
-		done <- session.Run(command)
-	}()
-
+	go func() { done <- session.Wait() }()
 	select {
 	case <-ctx.Done():
-		_ = session.Close()
-		return ctx.Err()
-	case err := <-done:
-		if err != nil {
-			text := strings.TrimSpace(output.String())
-			if text != "" {
-				return fmt.Errorf("remote command failed: %s: %w", text, err)
-			}
-			return err
+		closeSSHSessionOnCancel(client, session)
+		return nil, nil, ctx.Err()
+	case runErr := <-done:
+		stdout, stdoutTruncated := stdoutCapture.snapshot()
+		stderr, stderrTruncated := stderrCapture.snapshot()
+		if stdoutTruncated {
+			return nil, stderr, fmt.Errorf("remote command stdout exceeds %d bytes", stdoutLimit)
 		}
-		return nil
+		if stderrTruncated {
+			return nil, stderr, fmt.Errorf("remote command stderr exceeds %d bytes", stderrLimit)
+		}
+		if runErr != nil {
+			detail := strings.TrimSpace(string(stderr))
+			if detail == "" {
+				detail = strings.TrimSpace(string(stdout))
+			}
+			if detail != "" {
+				return stdout, stderr, fmt.Errorf("remote command failed: %s: %w", detail, runErr)
+			}
+			return stdout, stderr, runErr
+		}
+		return stdout, stderr, nil
 	}
 }
 

--- a/internal/core/bootstrap_test.go
+++ b/internal/core/bootstrap_test.go
@@ -5,14 +5,22 @@ package core
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
+	"fmt"
+	"io"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cenvero/fleet/internal/transport"
 	"github.com/cenvero/fleet/internal/update"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestBootstrapServerDirectUploadsAgentAndUpdatesServer(t *testing.T) {
@@ -321,6 +329,464 @@ func TestValidateBootstrapServiceName(t *testing.T) {
 	for _, bad := range []string{"../evil", `dir\\evil`, "fleet agent", "x.service", "$(touch-pwned)", "-H", "--no-block", ""} {
 		if err := validateBootstrapServiceName(bad); err == nil {
 			t.Errorf("unsafe service name %q accepted", bad)
+		}
+	}
+}
+
+func TestBootstrapServerRetryUsesStoredInstallMetadataAndExplicitAgentPort(t *testing.T) {
+	t.Parallel()
+	configDir := filepath.Join(t.TempDir(), "fleet")
+	if _, err := Initialize(InitOptions{
+		ConfigDir: configDir, Alias: "fleet", DefaultMode: transport.ModeDirect,
+		CryptoAlgorithm: "ed25519", UpdateChannel: "stable", UpdatePolicy: update.PolicyNotifyOnly,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app, err := Open(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	loginKey := filepath.Join(t.TempDir(), "bootstrap-key")
+	if err := app.AddServer(ServerRecord{
+		Name: "retry-node", Address: "192.0.2.50", Port: 22, Mode: transport.ModeDirect,
+		Agent: AgentInstall{Status: "failed", LoginUser: "ubuntu", LoginPort: 2200, LoginKey: loginKey},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	agentBinary := filepath.Join(t.TempDir(), "fleet-agent")
+	if err := os.WriteFile(agentBinary, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	executor := &fakeBootstrapExecutor{}
+	app.BootstrapExecutor = executor
+	result, err := app.BootstrapServer("retry-node", BootstrapOptions{AgentBinaryPath: agentBinary})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.LoginUser != "ubuntu" || result.LoginPort != 2200 {
+		t.Fatalf("stored login metadata not reused: %+v", result)
+	}
+	if len(executor.requests) != 1 || executor.requests[0].PrivateKeyPath != loginKey {
+		t.Fatalf("stored login key not reused: %+v", executor.requests)
+	}
+	if !strings.Contains(result.ServiceUnit, "0.0.0.0:22") {
+		t.Fatalf("explicit agent port 22 was replaced: %s", result.ServiceUnit)
+	}
+	stored, err := app.GetServer("retry-node")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Port != 22 || stored.Agent.Status != "managed" {
+		t.Fatalf("retry result metadata=%+v", stored)
+	}
+}
+
+func TestBoundedCaptureDrainsAfterLimit(t *testing.T) {
+	capture := newBoundedCapture(4)
+	if n, err := capture.Write([]byte("abcdef")); err != nil || n != 6 {
+		t.Fatalf("Write()=(%d,%v), want full 6-byte drain", n, err)
+	}
+	if n, err := capture.Write([]byte("gh")); err != nil || n != 2 {
+		t.Fatalf("second Write()=(%d,%v), want full drain", n, err)
+	}
+	got, truncated := capture.snapshot()
+	if string(got) != "abcd" || !truncated {
+		t.Fatalf("snapshot=(%q,%t), want bounded abcd and truncation", got, truncated)
+	}
+}
+
+func newBootstrapTestSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer
+}
+
+func startBootstrapTestSSHServer(t *testing.T, handler func(*ssh.ServerConn, <-chan ssh.NewChannel) error) (net.Conn, <-chan error) {
+	t.Helper()
+	return startBootstrapTestSSHServerWithSigner(t, newBootstrapTestSigner(t), handler)
+}
+
+func startBootstrapTestSSHServerWithSigner(t *testing.T, signer ssh.Signer, handler func(*ssh.ServerConn, <-chan ssh.NewChannel) error) (net.Conn, <-chan error) {
+	t.Helper()
+	config := &ssh.ServerConfig{
+		PasswordCallback: func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) {
+			return nil, nil
+		},
+	}
+	config.AddHostKey(signer)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		defer listener.Close()
+		serverConn, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		conn, channels, requests, err := ssh.NewServerConn(serverConn, config)
+		if err != nil {
+			done <- err
+			return
+		}
+		go ssh.DiscardRequests(requests)
+		err = handler(conn, channels)
+		_ = conn.Close()
+		done <- err
+	}()
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		_ = listener.Close()
+		t.Fatal(err)
+	}
+	return clientConn, done
+}
+
+func bootstrapTestRequest(t *testing.T) BootstrapRequest {
+	t.Helper()
+	return BootstrapRequest{
+		Address:          "bootstrap.test",
+		Port:             22,
+		User:             "tester",
+		Password:         "password",
+		KnownHostsPath:   filepath.Join(t.TempDir(), "known_hosts"),
+		AcceptNewHostKey: false,
+	}
+}
+
+func serveBootstrapTestExec(channels <-chan ssh.NewChannel) (string, error) {
+	newChannel, ok := <-channels
+	if !ok {
+		return "", fmt.Errorf("SSH connection closed before cleanup command")
+	}
+	channel, requests, err := newChannel.Accept()
+	if err != nil {
+		return "", err
+	}
+	defer channel.Close()
+	request, ok := <-requests
+	if !ok || request.Type != "exec" {
+		return "", fmt.Errorf("expected cleanup exec request")
+	}
+	var payload struct{ Command string }
+	if err := ssh.Unmarshal(request.Payload, &payload); err != nil {
+		return "", err
+	}
+	if err := request.Reply(true, nil); err != nil {
+		return "", err
+	}
+	_, _ = io.Copy(io.Discard, channel)
+	_, _ = channel.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{0}))
+	return payload.Command, nil
+}
+
+func TestSSHBootstrapExecutorCancellationInterruptsChannelOpen(t *testing.T) {
+	clientConn, serverDone := startBootstrapTestSSHServer(t, func(conn *ssh.ServerConn, _ <-chan ssh.NewChannel) error {
+		return conn.Wait()
+	})
+	executor := sshBootstrapExecutor{networkDialContext: func(context.Context, string, string) (net.Conn, error) {
+		return clientConn, nil
+	}}
+	req := bootstrapTestRequest(t)
+	req.Uploads = []BootstrapUpload{{Path: "/tmp/cancel-stage", Mode: 0o600, Content: []byte("payload")}}
+	req.RunCommand = "true"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := executor.Bootstrap(ctx, req)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Bootstrap() error=%v, want context deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("channel-open cancellation took %s, want <= 2s", elapsed)
+	}
+	select {
+	case <-serverDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSH test server did not stop after client cancellation")
+	}
+}
+
+func TestSSHBootstrapExecutorCancellationInterruptsExecRequest(t *testing.T) {
+	clientConn, serverDone := startBootstrapTestSSHServer(t, func(_ *ssh.ServerConn, channels <-chan ssh.NewChannel) error {
+		newChannel, ok := <-channels
+		if !ok {
+			return nil
+		}
+		channel, requests, err := newChannel.Accept()
+		if err != nil {
+			return err
+		}
+		request, ok := <-requests
+		if !ok || request.Type != "exec" {
+			_ = channel.Close()
+			return fmt.Errorf("expected stalled exec request")
+		}
+		for range requests {
+		}
+		_ = channel.Close()
+		cleanup, err := serveBootstrapTestExec(channels)
+		if err != nil {
+			return err
+		}
+		if cleanup != "rm -f '/tmp/cancel-exec' '/tmp/cancel-exec.part'" {
+			return fmt.Errorf("unexpected cleanup command %q", cleanup)
+		}
+		return nil
+	})
+	executor := sshBootstrapExecutor{networkDialContext: func(context.Context, string, string) (net.Conn, error) {
+		return clientConn, nil
+	}}
+	req := bootstrapTestRequest(t)
+	req.Uploads = []BootstrapUpload{{Path: "/tmp/cancel-exec", Mode: 0o600, Content: []byte("payload")}}
+	req.RunCommand = "true"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := executor.Bootstrap(ctx, req)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Bootstrap() error=%v, want context deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("exec-request cancellation took %s, want <= 2s", elapsed)
+	}
+	select {
+	case <-serverDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSH test server did not stop after exec cancellation")
+	}
+}
+
+func TestSSHBootstrapExecutorCleansAttemptedPathsAfterUploadFailure(t *testing.T) {
+	commands := make(chan string, 4)
+	clientConn, serverDone := startBootstrapTestSSHServer(t, func(_ *ssh.ServerConn, channels <-chan ssh.NewChannel) error {
+		commandNumber := 0
+		for newChannel := range channels {
+			if newChannel.ChannelType() != "session" {
+				_ = newChannel.Reject(ssh.UnknownChannelType, "session required")
+				continue
+			}
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				return err
+			}
+			request, ok := <-requests
+			if !ok || request.Type != "exec" {
+				_ = channel.Close()
+				return fmt.Errorf("expected exec request")
+			}
+			var payload struct{ Command string }
+			if err := ssh.Unmarshal(request.Payload, &payload); err != nil {
+				_ = channel.Close()
+				return err
+			}
+			commands <- payload.Command
+			commandNumber++
+			if err := request.Reply(true, nil); err != nil {
+				_ = channel.Close()
+				return err
+			}
+			_, _ = io.Copy(io.Discard, channel)
+			status := uint32(0)
+			if commandNumber == 2 {
+				status = 1
+			}
+			_, _ = channel.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{status}))
+			_ = channel.Close()
+			if commandNumber == 3 {
+				return nil
+			}
+		}
+		return nil
+	})
+	executor := sshBootstrapExecutor{networkDialContext: func(context.Context, string, string) (net.Conn, error) {
+		return clientConn, nil
+	}}
+	req := bootstrapTestRequest(t)
+	req.Uploads = []BootstrapUpload{
+		{Path: "/tmp/fleet-first", Mode: 0o600, Content: []byte("first")},
+		{Path: "/tmp/fleet-second", Mode: 0o600, Content: []byte("second")},
+	}
+	req.RunCommand = "true"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := executor.Bootstrap(ctx, req); err == nil {
+		t.Fatal("Bootstrap() unexpectedly succeeded after second upload failure")
+	}
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("SSH test server: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSH test server did not observe cleanup command")
+	}
+	close(commands)
+	var got []string
+	for command := range commands {
+		got = append(got, command)
+	}
+	if len(got) != 3 {
+		t.Fatalf("commands=%#v, want two uploads followed by cleanup", got)
+	}
+	if !strings.Contains(got[0], "'/tmp/fleet-first'") || !strings.Contains(got[1], "'/tmp/fleet-second'") {
+		t.Fatalf("upload commands do not target expected paths: %#v", got[:2])
+	}
+	if got[2] != "rm -f '/tmp/fleet-first' '/tmp/fleet-first.part' '/tmp/fleet-second' '/tmp/fleet-second.part'" {
+		t.Fatalf("cleanup command=%q", got[2])
+	}
+}
+
+func TestRemoteUploadCommandRejectsTruncatedInputAtomically(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "fleet-stage")
+	upload := BootstrapUpload{Path: destination, Mode: 0o700, Content: []byte("complete-payload")}
+	cmd := exec.Command("/bin/sh", "-c", buildRemoteUploadCommand(upload))
+	cmd.Stdin = strings.NewReader("truncated")
+	if output, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("truncated upload unexpectedly succeeded: %q", output)
+	}
+	for _, path := range []string{destination, remoteUploadPartialPath(destination)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("truncated upload left %q behind, stat error=%v", path, err)
+		}
+	}
+}
+
+func TestSSHBootstrapExecutorCancellationInterruptsSessionWait(t *testing.T) {
+	reachedWait := make(chan struct{})
+	clientConn, serverDone := startBootstrapTestSSHServer(t, func(_ *ssh.ServerConn, channels <-chan ssh.NewChannel) error {
+		newChannel, ok := <-channels
+		if !ok {
+			return nil
+		}
+		channel, requests, err := newChannel.Accept()
+		if err != nil {
+			return err
+		}
+		request, ok := <-requests
+		if !ok || request.Type != "exec" {
+			_ = channel.Close()
+			return fmt.Errorf("expected exec request")
+		}
+		if err := request.Reply(true, nil); err != nil {
+			_ = channel.Close()
+			return err
+		}
+		_, _ = io.Copy(io.Discard, channel)
+		close(reachedWait)
+		for range requests {
+		}
+		_ = channel.Close()
+		cleanup, err := serveBootstrapTestExec(channels)
+		if err != nil {
+			return err
+		}
+		if cleanup != "rm -f '/tmp/cancel-wait' '/tmp/cancel-wait.part'" {
+			return fmt.Errorf("unexpected cleanup command %q", cleanup)
+		}
+		return nil
+	})
+	executor := sshBootstrapExecutor{networkDialContext: func(context.Context, string, string) (net.Conn, error) {
+		return clientConn, nil
+	}}
+	req := bootstrapTestRequest(t)
+	req.Uploads = []BootstrapUpload{{Path: "/tmp/cancel-wait", Mode: 0o600, Content: []byte("payload")}}
+	req.RunCommand = "true"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := executor.Bootstrap(ctx, req)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Bootstrap() error=%v, want context deadline", err)
+	}
+	select {
+	case <-reachedWait:
+	default:
+		t.Fatal("server did not reach the stalled session.Wait phase")
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("session.Wait cancellation took %s, want <= 2s", elapsed)
+	}
+	select {
+	case <-serverDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSH test server did not stop after session.Wait cancellation")
+	}
+}
+
+func TestSSHBootstrapExecutorReconnectsForCleanupAfterChannelOpenCancellation(t *testing.T) {
+	signer := newBootstrapTestSigner(t)
+	firstConn, firstDone := startBootstrapTestSSHServerWithSigner(t, signer, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel) error {
+		if _, err := serveBootstrapTestExec(channels); err != nil {
+			return err
+		}
+		_ = conn.Wait()
+		return nil
+	})
+	cleanupCommands := make(chan string, 1)
+	secondConn, secondDone := startBootstrapTestSSHServerWithSigner(t, signer, func(_ *ssh.ServerConn, channels <-chan ssh.NewChannel) error {
+		command, err := serveBootstrapTestExec(channels)
+		if err == nil {
+			cleanupCommands <- command
+		}
+		return err
+	})
+	connections := make(chan net.Conn, 2)
+	connections <- firstConn
+	connections <- secondConn
+	executor := sshBootstrapExecutor{networkDialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		select {
+		case conn := <-connections:
+			return conn, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}}
+	req := bootstrapTestRequest(t)
+	req.Uploads = []BootstrapUpload{
+		{Path: "/tmp/reconnect-first", Mode: 0o600, Content: []byte("first")},
+		{Path: "/tmp/reconnect-second", Mode: 0o600, Content: []byte("second")},
+	}
+	req.RunCommand = "true"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	err := executor.Bootstrap(ctx, req)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Bootstrap() error=%v, want context deadline", err)
+	}
+	select {
+	case command := <-cleanupCommands:
+		want := "rm -f '/tmp/reconnect-first' '/tmp/reconnect-first.part' '/tmp/reconnect-second' '/tmp/reconnect-second.part'"
+		if command != want {
+			t.Fatalf("cleanup command=%q, want %q", command, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("fresh SSH connection did not receive cleanup command")
+	}
+	for name, done := range map[string]<-chan error{"first": firstDone, "second": secondDone} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%s SSH test server: %v", name, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s SSH test server did not stop", name)
 		}
 	}
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -172,6 +172,8 @@ func (s ServerRecord) WithoutEnrollSecret() ServerRecord {
 
 type AgentInstall struct {
 	Managed     bool      `toml:"managed" json:"managed"`
+	Status      string    `toml:"status,omitempty" json:"status,omitempty"`
+	LastError   string    `toml:"last_error,omitempty" json:"last_error,omitempty"`
 	BinaryPath  string    `toml:"binary_path,omitempty" json:"binary_path,omitempty"`
 	ServiceName string    `toml:"service_name,omitempty" json:"service_name,omitempty"`
 	LoginUser   string    `toml:"login_user,omitempty" json:"login_user,omitempty"`

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -13,6 +13,7 @@ import (
 	fleetalerts "github.com/cenvero/fleet/internal/alerts"
 	"github.com/cenvero/fleet/internal/core"
 	"github.com/cenvero/fleet/internal/logs"
+	"github.com/cenvero/fleet/internal/version"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	zone "github.com/lrstanley/bubblezone"
@@ -477,7 +478,7 @@ func renderServersTab(snapshot core.DashboardSnapshot, width, selected int) stri
 		fmt.Sprintf("Reachable: %s", yesNo(server.Observed.Reachable)),
 		fmt.Sprintf("Transport: %s", dashIfEmpty(server.Observed.Transport)),
 		fmt.Sprintf("Node: %s", dashIfEmpty(server.Observed.NodeName)),
-		fmt.Sprintf("Agent version: %s", dashIfEmpty(server.Observed.AgentVersion)),
+		fmt.Sprintf("Agent version: %s", version.DisplaySemVer(server.Observed.AgentVersion)),
 		fmt.Sprintf("OS/arch: %s", dashIfEmpty(strings.Trim(strings.Join([]string{server.Observed.OS, server.Observed.Arch}, "/"), "/"))),
 		fmt.Sprintf("Last seen: %s", dashIfEmpty(relativeTime(server.Observed.LastSeen))),
 		fmt.Sprintf("Host key: %s", truncate(dashIfEmpty(server.Observed.HostKeyFingerprint), 52)),

--- a/internal/update/http_retry.go
+++ b/internal/update/http_retry.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultHTTPGetAttempts = 3
+	defaultHTTPRetryDelay  = 500 * time.Millisecond
+	maxHTTPRetryDelay      = 30 * time.Second
+)
+
+type httpGetRetryPolicy struct {
+	attempts int
+	baseWait time.Duration
+	maxWait  time.Duration
+	wait     func(context.Context, time.Duration) error
+}
+
+func defaultHTTPGetRetryPolicy() httpGetRetryPolicy {
+	return httpGetRetryPolicy{
+		attempts: defaultHTTPGetAttempts,
+		baseWait: defaultHTTPRetryDelay,
+		maxWait:  maxHTTPRetryDelay,
+		wait:     waitForHTTPRetry,
+	}
+}
+
+// getHTTPBodyWithRetry performs a bounded sequence of idempotent GETs. The
+// client factory is invoked for each attempt so every retry gets a fresh request
+// deadline and re-runs the DNS-pinned redirect policy. Only transient transport
+// failures and 408/429/5xx responses are retried; URL/policy failures and other
+// permanent 4xx responses fail immediately.
+func getHTTPBodyWithRetry(
+	ctx context.Context,
+	rawURL string,
+	newClient func() *http.Client,
+	bodyLimit int64,
+	label string,
+	policy httpGetRetryPolicy,
+) ([]byte, error) {
+	if policy.attempts <= 0 {
+		policy.attempts = 1
+	}
+	if policy.baseWait < 0 {
+		policy.baseWait = 0
+	}
+	if policy.maxWait <= 0 {
+		policy.maxWait = maxHTTPRetryDelay
+	}
+	if policy.wait == nil {
+		policy.wait = waitForHTTPRetry
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= policy.attempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create %s request: %w", label, err)
+		}
+
+		resp, err := newClient().Do(req)
+		retry := false
+		retryAfter := ""
+		if err != nil {
+			lastErr = redactHTTPErrorURL(err)
+			retry = ctx.Err() == nil && isRetryableHTTPTransportError(err)
+		} else {
+			retryAfter = resp.Header.Get("Retry-After")
+			if resp.StatusCode == http.StatusOK {
+				data, readErr := readBoundedHTTPBody(resp.Body, bodyLimit, label)
+				closeErr := resp.Body.Close()
+				if readErr == nil && closeErr == nil {
+					return data, nil
+				}
+				if readErr != nil {
+					lastErr = readErr
+				} else {
+					lastErr = fmt.Errorf("close %s body: %w", label, closeErr)
+				}
+				// A short/truncated response can be retried safely. A body that
+				// crossed the explicit size bound is permanent and remains fail-closed.
+				retry = !strings.Contains(lastErr.Error(), "exceeds maximum size")
+			} else {
+				_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+				_ = resp.Body.Close()
+				lastErr = fmt.Errorf("unexpected %s status %s", label, resp.Status)
+				retry = isRetryableHTTPStatus(resp.StatusCode)
+			}
+		}
+
+		if !retry || attempt == policy.attempts {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			if attempt > 1 {
+				return nil, fmt.Errorf("%s failed after %d attempts: %w", label, attempt, lastErr)
+			}
+			return nil, fmt.Errorf("%s: %w", label, lastErr)
+		}
+
+		delay := retryDelay(attempt, policy.baseWait, policy.maxWait, retryAfter, time.Now())
+		if err := policy.wait(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("%s: %w", label, lastErr)
+}
+
+func isRetryableHTTPTransportError(err error) bool {
+	for {
+		urlErr, ok := err.(*url.Error)
+		if !ok {
+			break
+		}
+		err = urlErr.Err
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func redactHTTPErrorURL(err error) error {
+	urlErr, ok := err.(*url.Error)
+	if !ok {
+		return err
+	}
+	redacted := *urlErr
+	redacted.Err = redactHTTPErrorURL(urlErr.Err)
+	if parsed, parseErr := url.Parse(redacted.URL); parseErr == nil {
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		redacted.URL = parsed.Redacted()
+	}
+	return &redacted
+}
+
+func isRetryableHTTPStatus(status int) bool {
+	switch status {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests,
+		http.StatusInternalServerError, http.StatusBadGateway,
+		http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func retryDelay(attempt int, baseWait, maxWait time.Duration, retryAfter string, now time.Time) time.Duration {
+	if delay, ok := parseRetryAfter(retryAfter, now); ok {
+		if delay > maxWait {
+			return maxWait
+		}
+		return delay
+	}
+	if baseWait <= 0 {
+		return 0
+	}
+	delay := baseWait
+	for i := 1; i < attempt && delay < maxWait; i++ {
+		if delay > maxWait/2 {
+			return maxWait
+		}
+		delay *= 2
+	}
+	if delay > maxWait {
+		return maxWait
+	}
+	return delay
+}
+
+func parseRetryAfter(raw string, now time.Time) (time.Duration, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		if seconds > int64(maxHTTPRetryDelay/time.Second) {
+			return maxHTTPRetryDelay, true
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(raw)
+	if err != nil {
+		return 0, false
+	}
+	if !when.After(now) {
+		return 0, true
+	}
+	return when.Sub(now), true
+}
+
+func waitForHTTPRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/update/http_retry_test.go
+++ b/internal/update/http_retry_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package update
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestHTTPGetRetriesTransientStatusAndHonorsRetryAfterCap(t *testing.T) {
+	attempts := 0
+	var waited []time.Duration
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts < 3 {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Status:     "503 Service Unavailable",
+				Header:     http.Header{"Retry-After": []string{"60"}},
+				Body:       io.NopCloser(strings.NewReader("retry")),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})}
+	policy := httpGetRetryPolicy{
+		attempts: 3,
+		baseWait: time.Millisecond,
+		maxWait:  2 * time.Second,
+		wait: func(_ context.Context, delay time.Duration) error {
+			waited = append(waited, delay)
+			return nil
+		},
+	}
+
+	body, err := getHTTPBodyWithRetry(context.Background(), "https://example.com/artifact", func() *http.Client { return client }, 1024, "artifact", policy)
+	if err != nil {
+		t.Fatalf("getHTTPBodyWithRetry() error = %v", err)
+	}
+	if string(body) != "ok" || attempts != 3 {
+		t.Fatalf("body=%q attempts=%d, want ok and 3 attempts", body, attempts)
+	}
+	if len(waited) != 2 || waited[0] != 2*time.Second || waited[1] != 2*time.Second {
+		t.Fatalf("waited=%v, want Retry-After capped to 2s on each retry", waited)
+	}
+}
+
+func TestHTTPGetDoesNotRetryPermanentStatus(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("missing")),
+		}, nil
+	})}
+	policy := httpGetRetryPolicy{attempts: 3, wait: func(context.Context, time.Duration) error { return nil }}
+
+	_, err := getHTTPBodyWithRetry(context.Background(), "https://example.com/missing", func() *http.Client { return client }, 1024, "artifact", policy)
+	if err == nil || !strings.Contains(err.Error(), "404 Not Found") {
+		t.Fatalf("error=%v, want permanent 404", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts=%d, want 1", attempts)
+	}
+}
+
+func TestHTTPGetRetriesTransientNetworkError(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, &net.DNSError{Err: "temporary resolver failure", IsTemporary: true}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("recovered")),
+		}, nil
+	})}
+	policy := httpGetRetryPolicy{attempts: 3, wait: func(context.Context, time.Duration) error { return nil }}
+
+	body, err := getHTTPBodyWithRetry(context.Background(), "https://example.com/artifact", func() *http.Client { return client }, 1024, "artifact", policy)
+	if err != nil {
+		t.Fatalf("getHTTPBodyWithRetry() error = %v", err)
+	}
+	if string(body) != "recovered" || attempts != 2 {
+		t.Fatalf("body=%q attempts=%d, want recovered and 2 attempts", body, attempts)
+	}
+}
+
+func TestHTTPGetCancellationStopsBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		cancel()
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("retry")),
+		}, nil
+	})}
+	policy := httpGetRetryPolicy{attempts: 3, baseWait: time.Hour, maxWait: time.Hour, wait: waitForHTTPRetry}
+
+	_, err := getHTTPBodyWithRetry(ctx, "https://example.com/artifact", func() *http.Client { return client }, 1024, "artifact", policy)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error=%v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts=%d, want 1", attempts)
+	}
+}
+
+func TestHTTPGetDoesNotRetryPolicyErrorWrappedByURLError(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, &url.Error{Op: "Get", URL: req.URL.String(), Err: errors.New("refusing update redirect to unapproved host")}
+	})}
+	policy := httpGetRetryPolicy{attempts: 3, wait: func(context.Context, time.Duration) error { return nil }}
+
+	_, err := getHTTPBodyWithRetry(context.Background(), "https://example.com/artifact?sig=secret", func() *http.Client { return client }, 1024, "artifact", policy)
+	if err == nil || !strings.Contains(err.Error(), "refusing update redirect") {
+		t.Fatalf("error=%v, want policy rejection", err)
+	}
+	if strings.Contains(err.Error(), "sig=secret") {
+		t.Fatalf("error leaked URL query parameters: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts=%d, want policy rejection to fail immediately", attempts)
+	}
+}

--- a/internal/update/manifest.go
+++ b/internal/update/manifest.go
@@ -77,25 +77,16 @@ func Fetch(ctx context.Context, manifestURL string) (Manifest, error) {
 		return Manifest{}, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	body, err := getHTTPBodyWithRetry(
+		ctx,
+		parsed.String(),
+		func() *http.Client { return newUpdateHTTPClient(30 * time.Second) },
+		maxManifestBytes,
+		"manifest",
+		defaultHTTPGetRetryPolicy(),
+	)
 	if err != nil {
-		return Manifest{}, fmt.Errorf("create manifest request: %w", err)
-	}
-
-	client := newUpdateHTTPClient(10 * time.Second)
-	resp, err := client.Do(req)
-	if err != nil {
-		return Manifest{}, fmt.Errorf("fetch manifest: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return Manifest{}, fmt.Errorf("unexpected manifest status %s", resp.Status)
-	}
-
-	body, err := readBoundedHTTPBody(resp.Body, maxManifestBytes, "manifest")
-	if err != nil {
-		return Manifest{}, err
+		return Manifest{}, fmt.Errorf("fetch release manifest: %w", err)
 	}
 
 	var manifest Manifest

--- a/internal/update/updater.go
+++ b/internal/update/updater.go
@@ -369,23 +369,14 @@ func downloadURLForHosts(ctx context.Context, rawURL string, approvedHosts map[s
 	if err := validateUpdateDestination(ctx, net.DefaultResolver, parsed); err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("create download request: %w", err)
-	}
-	resp, err := newUpdateHTTPClientForHosts(30*time.Second, approvedHosts).Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("download artifact: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected artifact status %s", resp.Status)
-	}
-	data, err := readBoundedHTTPBody(resp.Body, maxArtifactBytes, "artifact")
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return getHTTPBodyWithRetry(
+		ctx,
+		parsed.String(),
+		func() *http.Client { return newUpdateHTTPClientForHosts(2*time.Minute, approvedHosts) },
+		maxArtifactBytes,
+		"artifact",
+		defaultHTTPGetRetryPolicy(),
+	)
 }
 
 func readBoundedHTTPBody(body io.Reader, limit int64, label string) ([]byte, error) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,6 +3,12 @@
 
 package version
 
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
 const ProductName = "Cenvero Fleet"
 const BinaryName = "fleet"
 const Domain = "fleet.cenvero.org"
@@ -16,4 +22,37 @@ func Canonical(v string) string {
 		return v
 	}
 	return "v" + v
+}
+
+// NormalizeSemVer trims a release version, validates strict semantic versioning,
+// and returns one consistent v-prefixed representation. Sentinel, development,
+// and malformed values are unavailable rather than misleading display values.
+func NormalizeSemVer(raw string) (string, bool) {
+	value := strings.TrimSpace(raw)
+	switch strings.ToLower(value) {
+	case "", "-", "dev", "unknown", "unavailable", "n/a":
+		return "", false
+	}
+	if strings.HasPrefix(value, "V") {
+		return "", false
+	}
+	if !strings.HasPrefix(value, "v") {
+		value = "v" + value
+	}
+	core := strings.TrimPrefix(value, "v")
+	if suffix := strings.IndexAny(core, "-+"); suffix >= 0 {
+		core = core[:suffix]
+	}
+	if strings.Count(core, ".") != 2 || !semver.IsValid(value) {
+		return "", false
+	}
+	return value, true
+}
+
+// DisplaySemVer returns a consistent release version for human-facing output.
+func DisplaySemVer(raw string) string {
+	if normalized, ok := NormalizeSemVer(raw); ok {
+		return normalized
+	}
+	return "-"
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cenvero / Shubhdeep Singh
+
+package version
+
+import "testing"
+
+func TestNormalizeSemVer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		raw  string
+		want string
+		ok   bool
+	}{
+		{raw: "2.4.2", want: "v2.4.2", ok: true},
+		{raw: " v2.4.2 ", want: "v2.4.2", ok: true},
+		{raw: "2.4.2-beta.1+build.7", want: "v2.4.2-beta.1+build.7", ok: true},
+		{raw: "", ok: false},
+		{raw: "   ", ok: false},
+		{raw: "unknown", ok: false},
+		{raw: "unavailable", ok: false},
+		{raw: "version unavailable", ok: false},
+		{raw: "n/a", ok: false},
+		{raw: "-", ok: false},
+		{raw: "dev", ok: false},
+		{raw: "V2.4.2", ok: false},
+		{raw: "2.4", ok: false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+			got, ok := NormalizeSemVer(tt.raw)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("NormalizeSemVer(%q)=(%q,%t), want (%q,%t)", tt.raw, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestDisplaySemVerUsesPlaceholderForUnavailable(t *testing.T) {
+	t.Parallel()
+	if got := DisplaySemVer("2.4.0"); got != "v2.4.0" {
+		t.Fatalf("DisplaySemVer(valid)=%q", got)
+	}
+	if got := DisplaySemVer("version unavailable"); got != "-" {
+		t.Fatalf("DisplaySemVer(unavailable)=%q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Restore SSH-first Linux agent onboarding: connect and pin the host first, detect its architecture with `uname`, then make the target fetch only its matching release with BusyBox-compatible `wget` retries and `curl` fallback.
- Keep controller-side fail-closed verification of exact release/target URLs, minisign trusted comments, size, SHA-256, and bounded extraction before atomic installation.
- Fix duplicate onboarding, configured ports, install/reconciliation state, non-secret retry metadata, canonical version display, updater HTTP retries, cancellation, and staging cleanup.
- Prepare the stable v2.4.3 changelog entry.

Operator impact: automatic Linux agent installation again uses the target server's network path instead of downloading all agent archives on the controller, while retaining the v2.4 security verification model.

## Scope

- Included: agent bootstrap/acquisition, onboarding lifecycle and ports, updater retry resilience, version presentation, tests, operations docs, and v2.4.3 release notes.
- Not included: controller-side GitHub agent archive acquisition, weakened artifact verification, or any Microsoft WinGet publication/submission. Existing release automation may generate and locally validate a WinGet manifest artifact, but this PR does not submit it to Microsoft's catalog.

## Verification

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] `make scale` if transport, metrics, TUI, or performance-sensitive behavior changed
- [x] `make release-ready` if release tooling, updates, signing, or docs for release flow changed

List any additional focused commands I ran:

```text
go test ./... -count=1
go vet ./...
go build ./cmd/fleet ./cmd/fleet-agent
go test -race ./internal/core ./internal/update -count=1
go test ./internal/core -run 'Test(AgentTarget|FetchVerifiedAgentRelease|SelectedAgentRelease|RemoteAgentDownload|RemoteUploadCommand|SSHBootstrapExecutor|AutoInstall|BoundedCapture|BootstrapServer)' -count=1 -race
git diff --check
```

Canonical release readiness passed full tests, both builds, release-tooling smoke tests, and the 100-agent scale validation. An independent read-only release review returned APPROVED with no blockers.

## Documentation

- [x] Docs were updated if behavior, config, or release flow changed
- [ ] No docs update was needed

README, operations guidance, and CHANGELOG now describe the target-side acquisition and retained verification behavior.

## Release and Security Impact

- [ ] No release flow impact
- [ ] No security-sensitive impact
- [x] This change affects transport, crypto, update, bootstrap, or signing behavior

Notes: v2.4.3 is a stable patch release. The GitHub tag workflow will sign archives and generate the release manifest after merge. Required repository signing secrets are configured. No WinGet catalog submission will be performed.

## DCO

- [x] Commits are signed off with `git commit -s`
